### PR TITLE
Jeffrey jian/add edit transaction command

### DIFF
--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -33,6 +33,10 @@ public class CollectionUtil {
         return items != null && Arrays.stream(items).anyMatch(Objects::nonNull);
     }
 
+    /**
+     * Throws NullPointerException if {@code items} is null,
+     * and throws IllegalArgumentException if collection is empty.
+     */
     public static void requireNonEmptyCollection(Collection<?> items) {
         requireNonNull(items);
         if (items.isEmpty()) {

--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -32,4 +32,11 @@ public class CollectionUtil {
     public static boolean isAnyNonNull(Object... items) {
         return items != null && Arrays.stream(items).anyMatch(Objects::nonNull);
     }
+
+    public static void requireNonEmptyCollection(Collection<?> items) {
+        requireNonNull(items);
+        if (items.isEmpty()) {
+            throw new IllegalArgumentException("Collection should not be empty");
+        }
+    }
 }

--- a/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -82,6 +83,21 @@ public class CollectionUtilTest {
         assertTrue(CollectionUtil.isAnyNonNull(new Object(), null));
     }
 
+    @Test
+    public void requireNonEmptyCollection() {
+        // empty list
+        assertThrows(IllegalArgumentException.class, () ->
+                CollectionUtil.requireNonEmptyCollection(Collections.emptyList()));
+        assertThrows(IllegalArgumentException.class, () ->
+                CollectionUtil.requireNonEmptyCollection(Arrays.asList()));
+
+        // empty set
+        assertThrows(IllegalArgumentException.class, () ->
+                CollectionUtil.requireNonEmptyCollection(Collections.emptySet()));
+        assertThrows(IllegalArgumentException.class, () ->
+                CollectionUtil.requireNonEmptyCollection(new HashSet<>()));
+    }
+
     /**
      * Asserts that {@code CollectionUtil#requireAllNonNull(Object...)} throw {@code NullPointerException}
      * if {@code objects} or any element of {@code objects} is null.
@@ -104,5 +120,8 @@ public class CollectionUtilTest {
 
     private void assertNullPointerExceptionNotThrown(Collection<?> collection) {
         requireAllNonNull(collection);
+    }
+    private void assertIllegalArgumentExceptionThrown(Collection<?> collection) {
+        assertThrows(IllegalArgumentException.class, () -> CollectionUtil.requireNonEmptyCollection(collection));
     }
 }


### PR DESCRIPTION
`requireNonEmptyCollection` will be used to check if `Set<Expense>` is not empty.