### PR TITLE
Add list transaction command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -16,6 +16,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_TRANSACTIONS_LISTED_OVERVIEW = "%1$d transactions listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTransactionCommand.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.transaction.TransactionContainsPersonNamesPredicate;
+
+/**
+ * List all transactions that involve some specified persons, either as a payer or a payee.
+ * If no persons are specified, list all transactions.
+ */
+public class ListTransactionCommand extends Command {
+
+    public static final String COMMAND_WORD = "listTransaction";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all transactions that involve some specified "
+        + "persons, either as a payer or a payee. If no persons are specified, list all transactions. "
+        + "Parameters: "
+        + PREFIX_ADDRESS + "ADDRESS "
+        + "[" + PREFIX_NAME + "NAME]...\n"
+        + "Example: " + COMMAND_WORD + " "
+        + PREFIX_NAME + "John Doe ";
+
+    private final TransactionContainsPersonNamesPredicate predicate;
+
+    public ListTransactionCommand(TransactionContainsPersonNamesPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        if (predicate.isEmpty()) {
+            model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        } else {
+            model.updateFilteredTransactionList(predicate);
+        }
+        return new CommandResult(
+            String.format(Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, model.getFilteredTransactionList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ListTransactionCommand)) {
+            return false;
+        }
+
+        ListTransactionCommand otherFindCommand = (ListTransactionCommand) other;
+        return predicate.equals(otherFindCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .add("predicate", predicate)
+            .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListTransactionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ListTransactionCommand.COMMAND_WORD:
+            return new ListTransactionCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ListTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListTransactionCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.ArrayList;
@@ -23,14 +22,7 @@ public class ListTransactionCommandParser implements Parser<ListTransactionComma
      */
     public ListTransactionCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-
-        if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListTransactionCommand.MESSAGE_USAGE));
-        }
-
         Set<Name> nameList = ParserUtil.parseNames(argMultimap.getAllValues(PREFIX_NAME));
-
         return new ListTransactionCommand(new TransactionContainsPersonNamesPredicate(new ArrayList<>(nameList)));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ListTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListTransactionCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+import seedu.address.logic.commands.ListTransactionCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
+import seedu.address.model.transaction.TransactionContainsPersonNamesPredicate;
+
+/**
+ * Parses input arguments and creates a new ListTransactionCommand object
+ */
+public class ListTransactionCommandParser implements Parser<ListTransactionCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListTransactionCommand
+     * and returns a ListTransactionCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListTransactionCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListTransactionCommand.MESSAGE_USAGE));
+        }
+
+        Set<Name> nameList = ParserUtil.parseNames(argMultimap.getAllValues(PREFIX_NAME));
+
+        return new ListTransactionCommand(new TransactionContainsPersonNamesPredicate(new ArrayList<>(nameList)));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -150,4 +150,16 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses {@code Collection<String> names} into a {@code Set<Name>}.
+     */
+    public static Set<Name> parseNames(Collection<String> names) throws ParseException {
+        requireNonNull(names);
+        final Set<Name> nameSet = new HashSet<>();
+        for (String name : names) {
+            nameSet.add(parseName(name));
+        }
+        return nameSet;
+    }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -127,6 +127,26 @@ public class AddressBook implements ReadOnlyAddressBook {
         transactions.add(t);
     }
 
+    /**
+     * Replaces the given transaction {@code target} in the list with {@code editedTransaction}.
+     * {@code target} must exist in the address book.
+     * The transaction identity of {@code editedTransaction} must not be the same as another existing transaction
+     * in the address book.
+     */
+    public void setTransaction(Transaction target, Transaction editedTransaction) {
+        requireNonNull(editedTransaction);
+
+        transactions.setTransaction(target, editedTransaction);
+    }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeTransaction(Transaction key) {
+        transactions.remove(key);
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,23 +6,27 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
 
 /**
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
-    Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
-
     /**
-     * Replaces user prefs data with the data in {@code userPrefs}.
+     * {@code Predicate} that always evaluate to true
      */
-    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
+    Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Transaction> PREDICATE_SHOW_ALL_TRANSACTIONS = unused -> true;
 
     /**
      * Returns the user prefs.
      */
     ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Replaces user prefs data with the data in {@code userPrefs}.
+     */
+    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
 
     /**
      * Returns the user prefs' GUI settings.
@@ -45,17 +49,24 @@ public interface Model {
     void setAddressBookFilePath(Path addressBookFilePath);
 
     /**
+     * Returns the AddressBook
+     */
+    ReadOnlyAddressBook getAddressBook();
+
+    /**
      * Replaces address book data with the data in {@code addressBook}.
      */
     void setAddressBook(ReadOnlyAddressBook addressBook);
-
-    /** Returns the AddressBook */
-    ReadOnlyAddressBook getAddressBook();
 
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);
+
+    /**
+     * Returns true if a transaction with the same identity as {@code transaction} exists in the address book.
+     */
+    boolean hasTransaction(Transaction transaction);
 
     /**
      * Deletes the given person.
@@ -64,10 +75,22 @@ public interface Model {
     void deletePerson(Person target);
 
     /**
+     * Deletes the given transaction.
+     * The transaction must exist in the address book.
+     */
+    void deleteTransaction(Transaction target);
+
+    /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */
     void addPerson(Person person);
+
+    /**
+     * Adds the given transaction.
+     * {@code transaction} must not already exist in the address book.
+     */
+    void addTransaction(Transaction transaction);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
@@ -76,12 +99,35 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
-    /** Returns an unmodifiable view of the filtered person list */
+    /**
+     * Replaces the given transaction {@code target} with {@code editedTransaction}.
+     * {@code target} must exist in the address book.
+     * The transaction identity of {@code editedTransaction} must not be the same
+     * as another existing transaction in the address book.
+     */
+    void setTransaction(Transaction target, Transaction editedTransaction);
+
+    /**
+     * Returns an unmodifiable view of the filtered person list
+     */
     ObservableList<Person> getFilteredPersonList();
 
     /**
+     * Returns an unmodifiable view of the filtered transaction list
+     */
+    ObservableList<Transaction> getFilteredTransactionList();
+
+    /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the filter of the filtered transaction list to filter by the given {@code predicate}.
+     *
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredTransactionList(Predicate<Transaction> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Transaction> filteredTransactions;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredTransactions = new FilteredList<>(this.addressBook.getTransactionList());
     }
 
     public ModelManager() {
@@ -111,7 +114,31 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
-    //=========== Filtered Person List Accessors =============================================================
+    @Override
+    public void setTransaction(Transaction target, Transaction editedTransaction) {
+        requireAllNonNull(target, editedTransaction);
+
+        addressBook.setTransaction(target, editedTransaction);
+    }
+
+    @Override
+    public void deleteTransaction(Transaction target) {
+        addressBook.removeTransaction(target);
+    }
+
+    @Override
+    public void addTransaction(Transaction transaction) {
+        addressBook.addTransaction(transaction);
+        updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+    }
+
+    @Override
+    public boolean hasTransaction(Transaction transaction) {
+        requireNonNull(transaction);
+        return addressBook.hasTransaction(transaction);
+    }
+
+    //=========== Filtered Person & Transaction List Accessors ===============================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Person} backed by the internal list of
@@ -122,10 +149,24 @@ public class ModelManager implements Model {
         return filteredPersons;
     }
 
+    /**
+     * Returns an unmodifiable view of the list of {@code Transaction} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    public ObservableList<Transaction> getFilteredTransactionList() {
+        return filteredTransactions;
+    }
+
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
+        requireNonNull(predicate);
+        filteredTransactions.setPredicate(predicate);
     }
 
     @Override
@@ -142,7 +183,8 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
+                && filteredPersons.equals(otherModelManager.filteredPersons)
+                && filteredTransactions.equals(otherModelManager.filteredTransactions);
     }
 
 }

--- a/src/main/java/seedu/address/model/transaction/Transaction.java
+++ b/src/main/java/seedu/address/model/transaction/Transaction.java
@@ -14,7 +14,6 @@ import org.apache.commons.numbers.fraction.BigFraction;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
 import seedu.address.model.transaction.expense.Expense;
 
 /**
@@ -83,12 +82,12 @@ public class Transaction {
     /**
      * Returns the portion of the transaction that the person has to pay.
      *
-     * @param person the person to get the portion of
+     * @param personName the name of the person
      */
-    public BigFraction getPortion(Person person) {
+    public BigFraction getPortion(Name personName) {
         BigFraction totalWeight = getTotalWeight();
         return expenses.stream()
-            .filter(expense -> expense.getPersonName().equals(person.getName()))
+            .filter(expense -> expense.getPersonName().equals(personName))
             .map(expenses -> expenses.getWeight().value.multiply(this.amount.amount).divide(totalWeight))
             .reduce(BigFraction.ZERO, BigFraction::add);
     }
@@ -108,13 +107,23 @@ public class Transaction {
     }
 
     /**
-     * Returns true if the person is involved in this transaction.
+     * Returns true if the person with the given name is involved in this transaction, either as a payer or a payee.
      *
-     * @param person the person to check
+     * @param personName the name of the person
      */
-    public boolean isPersonInvolved(Person person) {
-        return expenses.stream()
-            .anyMatch(expense -> expense.getPersonName().equals(person.getName()));
+    public boolean isPersonInvolved(Name personName) {
+        return getAllInvolvedPersonNames().contains(personName);
+    }
+
+    /**
+     * Returns the names of all the persons involved in this transaction, either as a payer or a payee.
+     */
+    public Set<Name> getAllInvolvedPersonNames() {
+        Set<Name> names = expenses.stream()
+            .map(Expense::getPersonName)
+            .collect(Collectors.toSet());
+        names.add(payeeName);
+        return names;
     }
 
     /**

--- a/src/main/java/seedu/address/model/transaction/TransactionContainsPersonNamesPredicate.java
+++ b/src/main/java/seedu/address/model/transaction/TransactionContainsPersonNamesPredicate.java
@@ -1,0 +1,49 @@
+package seedu.address.model.transaction;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Name;
+
+/**
+ * Tests that a {@code Transaction} contains any of the names of all the {@code Person}, either as a payer or a payee.
+ * Name matching is exact and case-sensitive.
+ */
+public class TransactionContainsPersonNamesPredicate implements Predicate<Transaction> {
+    private final List<Name> personNames;
+
+    public TransactionContainsPersonNamesPredicate(List<Name> personNames) {
+        this.personNames = personNames;
+    }
+
+    public boolean isEmpty() {
+        return personNames.isEmpty();
+    }
+
+    @Override
+    public boolean test(Transaction transaction) {
+        return personNames.stream().anyMatch(transaction::isPersonInvolved);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TransactionContainsPersonNamesPredicate)) {
+            return false;
+        }
+
+        TransactionContainsPersonNamesPredicate otherPredicate =
+            (TransactionContainsPersonNamesPredicate) other;
+        return personNames.equals(otherPredicate.personNames);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("personNames", personNames).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/transaction/UniqueTransactionList.java
+++ b/src/main/java/seedu/address/model/transaction/UniqueTransactionList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.transaction.exceptions.DuplicateTransactionException;
 import seedu.address.model.transaction.exceptions.TransactionNotFoundException;
 
 /**
@@ -68,9 +69,14 @@ public class UniqueTransactionList implements Iterable<Transaction> {
 
     /**
      * Replaces the contents of this list with {@code transactions}.
+     * {@code transactions} must not contain duplicate transactions.
      */
     public void setTransactions(List<Transaction> transactions) {
         requireAllNonNull(transactions);
+        if (!transactionsAreUnique(transactions)) {
+            throw new DuplicateTransactionException();
+        }
+
         internalList.setAll(transactions);
     }
 
@@ -109,5 +115,19 @@ public class UniqueTransactionList implements Iterable<Transaction> {
     @Override
     public String toString() {
         return internalList.toString();
+    }
+
+    /**
+     * Returns true if {@code transactions} contains only unique transactions.
+     */
+    private boolean transactionsAreUnique(List<Transaction> transactions) {
+        for (int i = 0; i < transactions.size() - 1; i++) {
+            for (int j = i + 1; j < transactions.size(); j++) {
+                if (transactions.get(i).isSameTransaction(transactions.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/seedu/address/model/transaction/exceptions/DuplicateTransactionException.java
+++ b/src/main/java/seedu/address/model/transaction/exceptions/DuplicateTransactionException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.transaction.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Transactions (Transactions are considered duplicates if they have
+ * the same identity).
+ */
+public class DuplicateTransactionException extends RuntimeException {
+    public DuplicateTransactionException() {
+        super("Operation would result in duplicate transactions");
+    }
+}
+

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -124,6 +125,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addTransaction(Transaction transaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -139,7 +145,17 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasTransaction(Transaction transaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteTransaction(Transaction target) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -149,12 +165,27 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
+        public ObservableList<Transaction> getFilteredTransactionList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredTransactionList(Predicate<Transaction> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTransactionCommandTest.java
@@ -1,0 +1,96 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.Messages.MESSAGE_TRANSACTIONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTransactions.DINNER;
+import static seedu.address.testutil.TypicalTransactions.LUNCH;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
+import seedu.address.model.transaction.TransactionContainsPersonNamesPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListTransactionCommand.
+ */
+public class ListTransactionCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        // TODO: Add these typical transactions to getTypicalAddressBook()
+        model.addTransaction(LUNCH);
+        model.addTransaction(DINNER);
+        expectedModel.addTransaction(LUNCH);
+        expectedModel.addTransaction(DINNER);
+    }
+
+    @Test
+    public void equals() {
+        TransactionContainsPersonNamesPredicate firstPredicate =
+            new TransactionContainsPersonNamesPredicate(Collections.singletonList(new Name("first")));
+        TransactionContainsPersonNamesPredicate secondPredicate =
+            new TransactionContainsPersonNamesPredicate(Collections.singletonList(new Name("second")));
+
+        ListTransactionCommand listFirstCommand = new ListTransactionCommand(firstPredicate);
+        ListTransactionCommand listSecondCommand = new ListTransactionCommand(secondPredicate);
+
+        // same object -> returns true
+        assertEquals(listFirstCommand, listFirstCommand);
+
+        // same values -> returns true
+        ListTransactionCommand listFirstCommandCopy = new ListTransactionCommand(firstPredicate);
+        assertEquals(listFirstCommand, listFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, listFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, listFirstCommand);
+
+        // different person name -> returns false
+        assertNotEquals(listFirstCommand, listSecondCommand);
+    }
+
+    @Test
+    public void execute_zeroNames_allTransactionsFound() {
+        String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 2);
+        TransactionContainsPersonNamesPredicate predicate =
+            new TransactionContainsPersonNamesPredicate(Collections.emptyList());
+        assertCommandSuccess(new ListTransactionCommand(predicate), model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleNames_multipleTransactionsFound() {
+        String expectedMessage = String.format(MESSAGE_TRANSACTIONS_LISTED_OVERVIEW, 1);
+        TransactionContainsPersonNamesPredicate predicate =
+            new TransactionContainsPersonNamesPredicate(Arrays.asList(new Name(VALID_NAME_BOB), new Name("Carl")));
+        expectedModel.updateFilteredTransactionList(predicate);
+        assertCommandSuccess(new ListTransactionCommand(predicate), model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void toStringMethod() {
+        TransactionContainsPersonNamesPredicate predicate =
+            new TransactionContainsPersonNamesPredicate(Arrays.asList(new Name("Bob"), new Name("Carl")));
+        ListTransactionCommand listTransactionCommand = new ListTransactionCommand(predicate);
+        String expected = ListTransactionCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, listTransactionCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -22,9 +26,12 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListTransactionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.transaction.TransactionContainsPersonNamesPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -49,7 +56,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
@@ -58,7 +65,7 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+            + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
@@ -72,7 +79,7 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+            FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -86,6 +93,15 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_listTransaction() throws Exception {
+        ListTransactionCommand command = (ListTransactionCommand) parser.parseCommand(
+            ListTransactionCommand.COMMAND_WORD + " " + NAME_DESC_AMY + " " + NAME_DESC_BOB);
+        TransactionContainsPersonNamesPredicate predicate = new TransactionContainsPersonNamesPredicate(
+            List.of(new Name(VALID_NAME_AMY), new Name(VALID_NAME_BOB)));
+        assertEquals(new ListTransactionCommand(predicate), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ListTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListTransactionCommandParserTest.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ListTransactionCommand;
+import seedu.address.model.person.Name;
+import seedu.address.model.transaction.TransactionContainsPersonNamesPredicate;
+
+public class ListTransactionCommandParserTest {
+    private final ListTransactionCommandParser parser = new ListTransactionCommandParser();
+
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        // zero keywords
+        ListTransactionCommand expectedListTransactionCommand =
+            new ListTransactionCommand(new TransactionContainsPersonNamesPredicate(List.of()));
+        assertParseSuccess(parser, "", expectedListTransactionCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n \t \n", expectedListTransactionCommand);
+    }
+
+    @Test
+    public void parse_validOptionalFields_success() {
+        // one keyword
+        ListTransactionCommand expectedListTransactionCommand =
+            new ListTransactionCommand(new TransactionContainsPersonNamesPredicate(List.of(new Name(VALID_NAME_AMY))));
+        assertParseSuccess(parser, NAME_DESC_AMY, expectedListTransactionCommand);
+
+        // multiple different keywords
+        expectedListTransactionCommand =
+            new ListTransactionCommand(new TransactionContainsPersonNamesPredicate(List.of(
+                new Name(VALID_NAME_AMY),
+                new Name(VALID_NAME_BOB)
+            )));
+        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB, expectedListTransactionCommand);
+
+        // duplicate keywords
+        expectedListTransactionCommand =
+            new ListTransactionCommand(new TransactionContainsPersonNamesPredicate(List.of(new Name(VALID_NAME_AMY))));
+        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_AMY, expectedListTransactionCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -22,7 +22,9 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.transaction.Transaction;
+import seedu.address.model.transaction.exceptions.DuplicateTransactionException;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TransactionBuilder;
 
 public class AddressBookTest {
 
@@ -31,6 +33,7 @@ public class AddressBookTest {
     @Test
     public void constructor() {
         assertEquals(Collections.emptyList(), addressBook.getPersonList());
+        assertEquals(Collections.emptyList(), addressBook.getTransactionList());
     }
 
     @Test
@@ -82,6 +85,23 @@ public class AddressBookTest {
     }
 
     @Test
+    public void resetData_withDuplicateTransactions_throwsDuplicateTransactionException() {
+        // Two transactions with the same identity fields
+        Transaction editedDinner = new TransactionBuilder(DINNER)
+            .withAmount(DINNER.getAmount().toString())
+            .withDescription(DINNER.getDescription().toString())
+            .withPayeeName(DINNER.getPayeeName().toString())
+            .withExpenses(DINNER.getExpenses())
+            .withTimestamp(DINNER.getTimestamp().toString())
+            .build();
+        List<Person> newPersons = List.of();
+        List<Transaction> newTransactions = Arrays.asList(DINNER, editedDinner);
+        AddressBookStub newData = new AddressBookStub(newPersons, newTransactions);
+
+        assertThrows(DuplicateTransactionException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
     public void hasTransaction_nullTransaction_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> addressBook.hasTransaction(null));
     }
@@ -96,6 +116,7 @@ public class AddressBookTest {
         addressBook.addTransaction(DINNER);
         assertTrue(addressBook.hasTransaction(DINNER));
     }
+
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getPersonList().remove(0));

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,6 +7,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalTransactions.LUNCH;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -78,8 +79,18 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasTransaction_nullTransaction_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasTransaction(null));
+    }
+
+    @Test
     public void hasPerson_personNotInAddressBook_returnsFalse() {
         assertFalse(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void hasTransaction_transactionNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasTransaction(LUNCH));
     }
 
     @Test
@@ -89,8 +100,20 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasTransaction_transactionInAddressBook_returnsTrue() {
+        modelManager.addTransaction(LUNCH);
+        assertTrue(modelManager.hasTransaction(LUNCH));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void getFilteredTransactionList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(
+            UnsupportedOperationException.class, () -> modelManager.getFilteredTransactionList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/transaction/TransactionContainsPersonNamesPredicateTest.java
+++ b/src/test/java/seedu/address/model/transaction/TransactionContainsPersonNamesPredicateTest.java
@@ -1,0 +1,92 @@
+package seedu.address.model.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalExpenses.ALICE_EXPENSE;
+import static seedu.address.testutil.TypicalExpenses.BOB_EXPENSE;
+import static seedu.address.testutil.TypicalExpenses.CARL_EXPENSE;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.CARL;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.Name;
+import seedu.address.testutil.TransactionBuilder;
+
+public class TransactionContainsPersonNamesPredicateTest {
+    @Test
+    public void equals() {
+        List<Name> firstPredicateNameList = List.of(new Name("first"));
+        List<Name> secondPredicateNameList = List.of(new Name("first"), new Name("second"));
+
+        TransactionContainsPersonNamesPredicate firstPredicate =
+            new TransactionContainsPersonNamesPredicate(firstPredicateNameList);
+        TransactionContainsPersonNamesPredicate secondPredicate =
+            new TransactionContainsPersonNamesPredicate(secondPredicateNameList);
+
+        // same object -> returns true
+        assertEquals(firstPredicate, firstPredicate);
+
+        // same values -> returns true
+        TransactionContainsPersonNamesPredicate firstPredicateCopy =
+            new TransactionContainsPersonNamesPredicate(firstPredicateNameList);
+        assertEquals(firstPredicate, firstPredicateCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, firstPredicate);
+
+        // null -> returns false
+        assertNotEquals(null, firstPredicate);
+
+        // different name list -> returns false
+        assertNotEquals(firstPredicate, secondPredicate);
+    }
+
+    @Test
+    public void test_transactionContainsPersonNames_returnsTrue() {
+        // One name
+        TransactionContainsPersonNamesPredicate predicate =
+            new TransactionContainsPersonNamesPredicate(List.of(CARL.getName()));
+        assertTrue(predicate.test(new TransactionBuilder().withPayeeName(CARL.getName().fullName).build()));
+        assertTrue(predicate.test(new TransactionBuilder().withExpenses(Set.of(CARL_EXPENSE)).build()));
+
+        // Multiple names
+        predicate = new TransactionContainsPersonNamesPredicate(List.of(BOB.getName(), CARL.getName()));
+        assertTrue(predicate.test(new TransactionBuilder().withPayeeName(CARL.getName().fullName).build()));
+        assertTrue(predicate.test(new TransactionBuilder()
+            .withPayeeName(ALICE.getName().fullName).withExpenses(Set.of(BOB_EXPENSE, CARL_EXPENSE)).build()));
+        assertTrue(predicate.test(new TransactionBuilder().withExpenses(Set.of(BOB_EXPENSE)).build()));
+        assertTrue(predicate.test(new TransactionBuilder().withExpenses(Set.of(ALICE_EXPENSE, CARL_EXPENSE)).build()));
+    }
+
+    @Test
+    public void test_transactionDoesNotContainPersonNames_returnsFalse() {
+        // Zero names
+        TransactionContainsPersonNamesPredicate predicate =
+            new TransactionContainsPersonNamesPredicate(List.of());
+        assertFalse(predicate.test(new TransactionBuilder().withPayeeName(CARL.getName().fullName).build()));
+        assertFalse(predicate.test(new TransactionBuilder().withExpenses(Set.of(CARL_EXPENSE)).build()));
+
+        // Non-matching name
+        predicate = new TransactionContainsPersonNamesPredicate(List.of(new Name("Carol")));
+        assertFalse(predicate.test(new TransactionBuilder().withPayeeName(CARL.getName().fullName).build()));
+        assertFalse(predicate.test(new TransactionBuilder().withExpenses(Set.of(CARL_EXPENSE)).build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<Name> names = List.of(new Name("name1"), new Name("name2"));
+        TransactionContainsPersonNamesPredicate predicate =
+            new TransactionContainsPersonNamesPredicate(names);
+
+        String expected = TransactionContainsPersonNamesPredicate.class.getCanonicalName()
+            + "{personNames=" + names + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/transaction/TransactionTest.java
+++ b/src/test/java/seedu/address/model/transaction/TransactionTest.java
@@ -11,6 +11,7 @@ import static seedu.address.testutil.TypicalExpenses.CARL_EXPENSE;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -110,44 +111,60 @@ class TransactionTest {
     }
 
     @Test
-    public void isPersonInvolved_expenseWithPersonNotInTransaction_returnsFalse() {
-        Set<Expense> expenses = Set.of(ALICE_EXPENSE);
-        Transaction transaction = new TransactionBuilder().withExpenses(expenses).build();
-        Person person = new PersonBuilder().withName(BOB.getName().fullName).build();
-        assertFalse(transaction.isPersonInvolved(person));
+    public void isPersonInvolved_payerInTransaction_returnsTrue() {
+        Set<Expense> expenses = Set.of(ALICE_EXPENSE, CARL_EXPENSE);
+        Transaction transaction = new TransactionBuilder()
+            .withPayeeName(BOB.getName().fullName).withExpenses(expenses).build();
+        assertTrue(transaction.isPersonInvolved(ALICE.getName()));
+        assertTrue(transaction.isPersonInvolved(CARL.getName()));
     }
 
     @Test
-    public void isPersonInvolved_expenseWithPersonInTransaction_returnsTrue() {
-        Set<Expense> expenses = Set.of(ALICE_EXPENSE);
-        Transaction transaction = new TransactionBuilder().withExpenses(expenses).build();
-        Person person = new PersonBuilder().withName(ALICE_EXPENSE.getPersonName().fullName).build();
-        assertTrue(transaction.isPersonInvolved(person));
+    public void isPersonInvolved_payeeInTransaction_returnsTrue() {
+        Set<Expense> expenses = Set.of(ALICE_EXPENSE, CARL_EXPENSE);
+        Transaction transaction = new TransactionBuilder()
+            .withPayeeName(BOB.getName().fullName).withExpenses(expenses).build();
+        assertTrue(transaction.isPersonInvolved(BOB.getName()));
+    }
+
+    @Test
+    public void isPersonInvolved_personNotInTransaction_returnsFalse() {
+        Set<Expense> expenses = Set.of(ALICE_EXPENSE, CARL_EXPENSE);
+        Transaction transaction = new TransactionBuilder()
+            .withPayeeName(BOB.getName().fullName).withExpenses(expenses).build();
+        assertFalse(transaction.isPersonInvolved(DANIEL.getName()));
+    }
+
+    @Test
+    public void getAllInvolvedPersonNames_transactionWithPayerAndPayee_returnsCorrectNames() {
+        Set<Expense> expenses = Set.of(ALICE_EXPENSE, CARL_EXPENSE);
+        Transaction transaction = new TransactionBuilder()
+            .withPayeeName(BOB.getName().fullName).withExpenses(expenses).build();
+        assertEquals(Set.of(ALICE.getName(), CARL.getName(), BOB.getName()), transaction.getAllInvolvedPersonNames());
     }
 
     @Test
     public void getPortion_singleExpense_returnsCorrectPortion() {
         Set<Expense> expenses = Set.of(ALICE_EXPENSE);
         Transaction transaction = new TransactionBuilder().withAmount("100").withExpenses(expenses).build();
-        Person person = new PersonBuilder().withName(ALICE_EXPENSE.getPersonName().fullName).build();
         BigFraction expectedPortion = BigFraction.of(100, 1);
-        assertEquals(expectedPortion, transaction.getPortion(person));
+        assertEquals(expectedPortion, transaction.getPortion(ALICE.getName()));
     }
 
     @Test
     public void getPortion_multipleExpenses_returnsCorrectPortion() {
         Set<Expense> expenses = Set.of(
-                ALICE_EXPENSE,
+            ALICE_EXPENSE,
             BOB_EXPENSE,
             CARL_EXPENSE
         );
         Transaction transaction = new TransactionBuilder().withAmount("600").withExpenses(expenses).build();
         assertEquals(BigFraction.of(100, 1),
-                transaction.getPortion(new PersonBuilder().withName(ALICE_EXPENSE.getPersonName().fullName).build()));
+                transaction.getPortion(ALICE.getName()));
         assertEquals(BigFraction.of(200, 1),
-                transaction.getPortion(new PersonBuilder().withName(BOB.getName().fullName).build()));
+                transaction.getPortion(BOB.getName()));
         assertEquals(BigFraction.of(300, 1),
-                transaction.getPortion(new PersonBuilder().withName(CARL.getName().fullName).build()));
+                transaction.getPortion(CARL.getName()));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TransactionBuilder.java
+++ b/src/test/java/seedu/address/testutil/TransactionBuilder.java
@@ -20,7 +20,7 @@ public class TransactionBuilder {
 
     public static final String DEFAULT_AMOUNT = "12.34";
     public static final String DEFAULT_DESCRIPTION = "Mala Xiang Guo at Clementi Mall on 12 Oct 2023";
-    public static final String DEFAULT_PAYEE_NAME = TypicalPersons.ALICE.getName().fullName;
+    public static final String DEFAULT_PAYEE_NAME = "Default Payee Name";
 
     private Amount amount;
     private Description description;


### PR DESCRIPTION
Closes #51 

- Add new classes `ListTransactionCommand`, `ListTransactionCommandParser`, `TransactionContainsPersonNamesPredicate` with tests to handle this function
- Usage: `listTransaction [/n Name]` returns all transactions that involve 1 of the given names (either as payer or payee), or all transactions if no names are given