### PR TITLE
Add settle command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
@@ -54,7 +54,6 @@ public class SettlePersonCommand extends Command {
         Person personToSettle = lastShownList.get(targetIndex.getZeroBased());
 
         model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
-        List<Transaction> transactions = model.getFilteredTransactionList();
 
         // total money the person owes the user
         BigFraction balance = model.getBalance(personToSettle.getName());

--- a/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
@@ -77,7 +77,7 @@ public class SettlePersonCommand extends Command {
 
         // create transaction to cancel out outstanding balance
         model.addTransaction(new Transaction(
-                new Amount(balance.toString()), description, name, expenses));
+                new Amount(balance.abs().toString()), description, name, expenses));
         return new CommandResult(String.format(MESSAGE_SETTLE_PERSON_SUCCESS, personToSettle.getName()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
@@ -66,10 +66,15 @@ public class SettlePersonCommand extends Command {
         Weight weight = new Weight(BigFraction.ONE.toString());
         Name name;
         Set<Expense> expenses;
+
         if (balance.signum() > 0) {
+            // if the balance is positive, the person owes the user money
+            // we create a transaction where the person pays the user back
             name = personToSettle.getName();
             expenses = Set.of(new Expense(Name.SELF, weight));
         } else {
+            // if the balance is negative, the user owes the person money
+            // we create a transaction where the user pays the person back
             name = Name.SELF;
             expenses = Set.of(new Expense(personToSettle.getName(), weight));
         }

--- a/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
@@ -57,9 +57,7 @@ public class SettlePersonCommand extends Command {
         List<Transaction> transactions = model.getFilteredTransactionList();
 
         // total money the person owes the user
-        BigFraction balance = transactions.stream()
-                .map(transaction -> transaction.getPortionOwed(personToSettle.getName()))
-                .reduce(BigFraction.ZERO, BigFraction::add);
+        BigFraction balance = model.getBalance(personToSettle.getName());
         if (balance.equals(BigFraction.ZERO)) {
             throw new CommandException(MESSAGE_NO_OUTSTANDING_BALANCE);
         }
@@ -79,7 +77,7 @@ public class SettlePersonCommand extends Command {
 
         // create transaction to cancel out outstanding balance
         model.addTransaction(new Transaction(
-                new Amount(balance.negate().toString()), description, name, expenses));
+                new Amount(balance.toString()), description, name, expenses));
         return new CommandResult(String.format(MESSAGE_SETTLE_PERSON_SUCCESS, personToSettle.getName()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SettlePersonCommand.java
@@ -1,0 +1,107 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TRANSACTIONS;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.numbers.fraction.BigFraction;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Amount;
+import seedu.address.model.transaction.Description;
+import seedu.address.model.transaction.Transaction;
+import seedu.address.model.transaction.expense.Expense;
+import seedu.address.model.transaction.expense.Weight;
+
+/**
+ * Settles any outstanding balance with a person.
+ */
+public class SettlePersonCommand extends Command {
+    public static final String COMMAND_WORD = "settlePerson";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Settle any outstanding balance with another person. "
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SETTLE_PERSON_SUCCESS = "Balance settled: %1$s";
+
+    public static final String MESSAGE_NO_OUTSTANDING_BALANCE = "There is no outstanding balance with this person.";
+
+    public static final String SETTLE_TRANSACTION_DESCRIPTION = "Settle balance with %1$s";
+
+    private final Index targetIndex;
+
+    public SettlePersonCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToSettle = lastShownList.get(targetIndex.getZeroBased());
+
+        model.updateFilteredTransactionList(PREDICATE_SHOW_ALL_TRANSACTIONS);
+        List<Transaction> transactions = model.getFilteredTransactionList();
+
+        // total money the person owes the user
+        BigFraction balance = transactions.stream()
+                .map(transaction -> transaction.getPortionOwed(personToSettle.getName()))
+                .reduce(BigFraction.ZERO, BigFraction::add);
+        if (balance.equals(BigFraction.ZERO)) {
+            throw new CommandException(MESSAGE_NO_OUTSTANDING_BALANCE);
+        }
+
+        Description description = new Description(String.format(
+                SETTLE_TRANSACTION_DESCRIPTION, personToSettle.getName()));
+        Weight weight = new Weight(BigFraction.ONE.toString());
+        Name name;
+        Set<Expense> expenses;
+        if (balance.signum() > 0) {
+            name = personToSettle.getName();
+            expenses = Set.of(new Expense(Name.SELF, weight));
+        } else {
+            name = Name.SELF;
+            expenses = Set.of(new Expense(personToSettle.getName(), weight));
+        }
+
+        // create transaction to cancel out outstanding balance
+        model.addTransaction(new Transaction(
+                new Amount(balance.negate().toString()), description, name, expenses));
+        return new CommandResult(String.format(MESSAGE_SETTLE_PERSON_SUCCESS, personToSettle.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof SettlePersonCommand)) {
+            return false;
+        }
+
+        SettlePersonCommand otherSettlePersonCommand = (SettlePersonCommand) other;
+        return targetIndex.equals(otherSettlePersonCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -72,7 +72,7 @@ public class AddressBookParser {
 
         case ListPersonCommand.COMMAND_WORD:
             return new ListPersonCommand();
-            
+
         case ListTransactionCommand.COMMAND_WORD:
             return new ListTransactionCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListPersonCommand;
 import seedu.address.logic.commands.ListTransactionCommand;
+import seedu.address.logic.commands.SettlePersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -71,15 +72,18 @@ public class AddressBookParser {
 
         case ListPersonCommand.COMMAND_WORD:
             return new ListPersonCommand();
+            
+        case ListTransactionCommand.COMMAND_WORD:
+            return new ListTransactionCommandParser().parse(arguments);
+
+        case SettlePersonCommand.COMMAND_WORD:
+            return new SettlePersonCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-
-        case ListTransactionCommand.COMMAND_WORD:
-            return new ListTransactionCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SettlePersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SettlePersonCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.SettlePersonCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new SettlePersonCommand object
+ */
+public class SettlePersonCommandParser implements Parser<SettlePersonCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SettlePersonCommand
+     * and returns a SettlePersonCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SettlePersonCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new SettlePersonCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SettlePersonCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -4,8 +4,11 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import org.apache.commons.numbers.fraction.BigFraction;
+
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.transaction.Transaction;
@@ -155,6 +158,17 @@ public class AddressBook implements ReadOnlyAddressBook {
                 .add("persons", persons)
                 .add("transactions", transactions)
                 .toString();
+    }
+
+    /**
+     * Returns the total balance of all transaction that the person has to pay the user.
+     *
+     * @param name the name of the person
+     */
+    public BigFraction getBalance(Name name) {
+        return transactions.asUnmodifiableObservableList().stream()
+                .map(transaction -> transaction.getPortionOwed(name))
+                .reduce(BigFraction.ZERO, BigFraction::add);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,8 +3,11 @@ package seedu.address.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
+import org.apache.commons.numbers.fraction.BigFraction;
+
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.transaction.Transaction;
 
@@ -106,6 +109,13 @@ public interface Model {
      * as another existing transaction in the address book.
      */
     void setTransaction(Transaction target, Transaction editedTransaction);
+
+    /**
+     * Returns the total balance of all transaction that the person has to pay the user.
+     *
+     * @param name the name of the person
+     */
+    BigFraction getBalance(Name name);
 
     /**
      * Returns an unmodifiable view of the filtered person list

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -7,10 +7,13 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import org.apache.commons.numbers.fraction.BigFraction;
+
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.transaction.Transaction;
 
@@ -136,6 +139,12 @@ public class ModelManager implements Model {
     public boolean hasTransaction(Transaction transaction) {
         requireNonNull(transaction);
         return addressBook.hasTransaction(transaction);
+    }
+
+    @Override
+    public BigFraction getBalance(Name name) {
+        requireNonNull(name);
+        return addressBook.getBalance(name);
     }
 
     //=========== Filtered Person & Transaction List Accessors ===============================================

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -9,6 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Name {
     public static final Name SELF = new Name("SELF");
+    public static final Name DELETED = new Name("DELETED");
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";

--- a/src/main/java/seedu/address/model/transaction/Transaction.java
+++ b/src/main/java/seedu/address/model/transaction/Transaction.java
@@ -109,6 +109,9 @@ public class Transaction {
 
     /**
      * Returns the portion of the transaction that the person has to pay the user.
+     * A positive amount indicates the amount the person owes the user.
+     * A negative amount indicates the amount the user owes the person.
+     * Zero amount indicates that the user has no net balance owed to the user from the transaction.
      *
      * @param personName the name of the person
      */

--- a/src/main/java/seedu/address/model/transaction/Transaction.java
+++ b/src/main/java/seedu/address/model/transaction/Transaction.java
@@ -113,8 +113,6 @@ public class Transaction {
      * @param personName the name of the person
      */
     public BigFraction getPortionOwed(Name personName) {
-        BigFraction totalWeight = getTotalWeight();
-
         // person is not relevant to user in the transaction
         if (!payeeName.equals(personName) && !payeeName.equals(Name.SELF)) {
             return BigFraction.ZERO;
@@ -127,17 +125,11 @@ public class Transaction {
 
         // user owes person money from the transaction
         if (payeeName.equals(personName)) {
-            return expenses.stream()
-                    .filter(expense -> expense.getPersonName().equals(Name.SELF))
-                    .map(expenses -> expenses.getWeight().value.multiply(this.amount.amount).divide(totalWeight))
-                    .reduce(BigFraction.ZERO, BigFraction::subtract);
+            return BigFraction.ZERO.subtract(getPortion(Name.SELF));
         }
 
         // person owes user money from the transaction
-        return expenses.stream()
-                .filter(expense -> expense.getPersonName().equals(personName))
-                .map(expenses -> expenses.getWeight().value.multiply(this.amount.amount).divide(totalWeight))
-                .reduce(BigFraction.ZERO, BigFraction::add);
+        return getPortion(personName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/transaction/Transaction.java
+++ b/src/main/java/seedu/address/model/transaction/Transaction.java
@@ -125,7 +125,7 @@ public class Transaction {
 
         // user owes person money from the transaction
         if (payeeName.equals(personName)) {
-            return BigFraction.ZERO.subtract(getPortion(Name.SELF));
+            return getPortion(Name.SELF).negate();
         }
 
         // person owes user money from the transaction

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
+import org.apache.commons.numbers.fraction.BigFraction;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
@@ -22,6 +23,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.testutil.PersonBuilder;
@@ -167,6 +169,11 @@ public class AddPersonCommandTest {
 
         @Override
         public void setTransaction(Transaction target, Transaction editedTransaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public BigFraction getBalance(Name name) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -20,6 +20,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.TransactionBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -36,6 +37,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TIMESTAMP = "2023-10-13T12:34:56.789";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -67,6 +69,27 @@ public class CommandTestUtil {
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+    }
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
+     * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
+     * - the {@code actualModel} matches {@code expectedModel} excluding transaction timestamps
+     */
+    public static void assertTransactionCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel) {
+        try {
+            CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+            CommandResult result = command.execute(actualModel);
+            actualModel.getFilteredTransactionList().forEach(transaction -> actualModel.setTransaction(transaction,
+                    new TransactionBuilder(transaction).withTimestamp(VALID_TIMESTAMP).build()));
+            expectedModel.getFilteredTransactionList().forEach(transaction -> expectedModel.setTransaction(transaction,
+                    new TransactionBuilder(transaction).withTimestamp(VALID_TIMESTAMP).build()));
+            assertEquals(expectedCommandResult, result);
+            assertEquals(expectedModel, actualModel);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/SettlePersonCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/SettlePersonCommandIntegrationTest.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertTransactionCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
+import seedu.address.testutil.ExpenseBuilder;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TransactionBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code SettlePersonCommand}.
+ */
+public class SettlePersonCommandIntegrationTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+    @Test
+    public void execute_settlePositiveBalance_success() {
+        Person personToSettle = new PersonBuilder(ALICE).build();
+        Name personToSettleName = personToSettle.getName();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Transaction transaction = new TransactionBuilder().withPayeeName(personToSettleName.fullName).withDescription(
+                String.format(SettlePersonCommand.SETTLE_TRANSACTION_DESCRIPTION, personToSettleName.fullName))
+                .withAmount(expectedModel.getBalance(personToSettleName).toString())
+                .withExpenses(Set.of(new ExpenseBuilder().withName(Name.SELF.fullName)
+                .withWeight("1").build())).build();
+        expectedModel.addTransaction(transaction);
+
+        assertTransactionCommandSuccess(new SettlePersonCommand(INDEX_FIRST_PERSON), model,
+                String.format(SettlePersonCommand.MESSAGE_SETTLE_PERSON_SUCCESS, personToSettle.getName()),
+                expectedModel);
+    }
+    @Test
+    public void execute_settleNegativeBalance_success() {
+        Person personToSettle = new PersonBuilder(BENSON).build();
+        Name personToSettleName = personToSettle.getName();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Transaction transaction = new TransactionBuilder().withPayeeName(Name.SELF.fullName).withDescription(
+                String.format(SettlePersonCommand.SETTLE_TRANSACTION_DESCRIPTION, personToSettleName.fullName))
+                .withAmount(expectedModel.getBalance(personToSettleName).abs().toString())
+                .withExpenses(Set.of(new ExpenseBuilder().withName(personToSettleName.fullName)
+                .withWeight("1").build())).build();
+        expectedModel.addTransaction(transaction);
+
+        assertTransactionCommandSuccess(new SettlePersonCommand(INDEX_SECOND_PERSON), model,
+                String.format(SettlePersonCommand.MESSAGE_SETTLE_PERSON_SUCCESS, personToSettle.getName()),
+                expectedModel);
+    }
+    @Test
+    public void execute_noOutstandingBalance_throwsCommandException() {
+        Person personToSettle = new PersonBuilder(ELLE).build();
+        Name personToSettleName = personToSettle.getName();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Transaction transaction = new TransactionBuilder().withPayeeName(personToSettleName.toString()).withDescription(
+                String.format(SettlePersonCommand.SETTLE_TRANSACTION_DESCRIPTION, personToSettleName.fullName))
+                .withAmount(expectedModel.getBalance(personToSettleName).toString())
+                .withExpenses(Set.of(new ExpenseBuilder().withName(Name.SELF.fullName)
+                .withWeight("1").build())).build();
+        expectedModel.addTransaction(transaction);
+
+        assertCommandFailure(new SettlePersonCommand(INDEX_FIFTH_PERSON),
+                model, SettlePersonCommand.MESSAGE_NO_OUTSTANDING_BALANCE);
+    }
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        SettlePersonCommand settlePersonCommand = new SettlePersonCommand(outOfBoundIndex);
+
+        assertCommandFailure(settlePersonCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SettlePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SettlePersonCommandTest.java
@@ -1,0 +1,8 @@
+package seedu.address.logic.commands;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code SettlePersonCommand}.
+ */
+public class SettlePersonCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/SettlePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SettlePersonCommandTest.java
@@ -1,8 +1,45 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+
 /**
- * Contains integration tests (interaction with the Model) and unit tests for
- * {@code SettlePersonCommand}.
+ * Contains unit tests for {@code SettlePersonCommand}.
  */
 public class SettlePersonCommandTest {
+    @Test
+    public void equals() {
+        SettlePersonCommand settleFirstCommand = new SettlePersonCommand(INDEX_FIRST_PERSON);
+        SettlePersonCommand settleSecondCommand = new SettlePersonCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertEquals(settleFirstCommand, settleFirstCommand);
+
+        // same values -> returns true
+        SettlePersonCommand settleFirstCommandCopy = new SettlePersonCommand(INDEX_FIRST_PERSON);
+        assertEquals(settleFirstCommand, settleFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, settleFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, settleFirstCommand);
+
+        // different person -> returns false
+        assertNotEquals(settleFirstCommand, settleSecondCommand);
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        SettlePersonCommand settleCommand = new SettlePersonCommand(targetIndex);
+        String expected = SettlePersonCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, settleCommand.toString());
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/SettlePersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SettlePersonCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SettlePersonCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the SettlePersonCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the SettlePersonCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class SettlePersonCommandParserTest {
+
+    private SettlePersonCommandParser parser = new SettlePersonCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsSettlePersonCommand() {
+        assertParseSuccess(parser, "1", new SettlePersonCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SettlePersonCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/transaction/TransactionTest.java
+++ b/src/test/java/seedu/address/model/transaction/TransactionTest.java
@@ -182,14 +182,14 @@ class TransactionTest {
     public void getPortionOwed_otherPayeeMultipleExpenses_returnsCorrectPortion() {
         Set<Expense> expenses = Set.of(
                 ALICE_EXPENSE,
-                BOB_EXPENSE,
+                BENSON_EXPENSE,
                 CARL_EXPENSE,
                 SELF_EXPENSE
         );
         Transaction transaction = new TransactionBuilder().withPayeeName(ALICE.getName().fullName)
                 .withAmount("1000").withExpenses(expenses).build();
         assertEquals(BigFraction.of(-400, 1), transaction.getPortionOwed(ALICE.getName()));
-        assertEquals(BigFraction.ZERO, transaction.getPortionOwed(BOB.getName()));
+        assertEquals(BigFraction.ZERO, transaction.getPortionOwed(BENSON.getName()));
         assertEquals(BigFraction.ZERO, transaction.getPortionOwed(CARL.getName()));
         assertEquals(BigFraction.ZERO, transaction.getPortionOwed(Name.SELF));
     }
@@ -206,7 +206,7 @@ class TransactionTest {
     public void getPortionOwed_selfPayeeMultipleExpenses_returnsCorrectPortion() {
         Set<Expense> expenses = Set.of(
                 ALICE_EXPENSE,
-                BOB_EXPENSE,
+                BENSON_EXPENSE,
                 CARL_EXPENSE,
                 SELF_EXPENSE
         );
@@ -215,7 +215,7 @@ class TransactionTest {
         assertEquals(BigFraction.of(100, 1),
                 transaction.getPortionOwed(ALICE.getName()));
         assertEquals(BigFraction.of(200, 1),
-                transaction.getPortionOwed(BOB.getName()));
+                transaction.getPortionOwed(BENSON.getName()));
         assertEquals(BigFraction.of(300, 1),
                 transaction.getPortionOwed(CARL.getName()));
         assertEquals(BigFraction.ZERO,

--- a/src/test/java/seedu/address/model/transaction/TransactionTest.java
+++ b/src/test/java/seedu/address/model/transaction/TransactionTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalExpenses.ALICE_EXPENSE;
 import static seedu.address.testutil.TypicalExpenses.BENSON_EXPENSE;
 import static seedu.address.testutil.TypicalExpenses.CARL_EXPENSE;
+import static seedu.address.testutil.TypicalExpenses.SELF_EXPENSE;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -167,6 +168,58 @@ class TransactionTest {
                 transaction.getPortion(BENSON.getName()));
         assertEquals(BigFraction.of(300, 1),
                 transaction.getPortion(CARL.getName()));
+    }
+
+    @Test
+    public void getPortionOwed_otherPayeeSingleExpense_returnsCorrectPortion() {
+        Set<Expense> expenses = Set.of(ALICE_EXPENSE);
+        Transaction transaction = new TransactionBuilder().withPayeeName(ALICE.getName().fullName)
+                .withAmount("100").withExpenses(expenses).build();
+        assertEquals(BigFraction.ZERO, transaction.getPortionOwed(ALICE.getName()));
+    }
+
+    @Test
+    public void getPortionOwed_otherPayeeMultipleExpenses_returnsCorrectPortion() {
+        Set<Expense> expenses = Set.of(
+                ALICE_EXPENSE,
+                BOB_EXPENSE,
+                CARL_EXPENSE,
+                SELF_EXPENSE
+        );
+        Transaction transaction = new TransactionBuilder().withPayeeName(ALICE.getName().fullName)
+                .withAmount("1000").withExpenses(expenses).build();
+        assertEquals(BigFraction.of(-400, 1), transaction.getPortionOwed(ALICE.getName()));
+        assertEquals(BigFraction.ZERO, transaction.getPortionOwed(BOB.getName()));
+        assertEquals(BigFraction.ZERO, transaction.getPortionOwed(CARL.getName()));
+        assertEquals(BigFraction.ZERO, transaction.getPortionOwed(Name.SELF));
+    }
+    @Test
+    public void getPortionOwed_selfPayeeSingleExpense_returnsCorrectPortion() {
+        Set<Expense> expenses = Set.of(ALICE_EXPENSE);
+        Transaction transaction = new TransactionBuilder().withPayeeName(Name.SELF.fullName)
+                .withAmount("100").withExpenses(expenses).build();
+        BigFraction expectedPortion = BigFraction.of(100, 1);
+        assertEquals(expectedPortion, transaction.getPortionOwed(ALICE.getName()));
+    }
+
+    @Test
+    public void getPortionOwed_selfPayeeMultipleExpenses_returnsCorrectPortion() {
+        Set<Expense> expenses = Set.of(
+                ALICE_EXPENSE,
+                BOB_EXPENSE,
+                CARL_EXPENSE,
+                SELF_EXPENSE
+        );
+        Transaction transaction = new TransactionBuilder().withPayeeName(Name.SELF.fullName)
+                .withAmount("1000").withExpenses(expenses).build();
+        assertEquals(BigFraction.of(100, 1),
+                transaction.getPortionOwed(ALICE.getName()));
+        assertEquals(BigFraction.of(200, 1),
+                transaction.getPortionOwed(BOB.getName()));
+        assertEquals(BigFraction.of(300, 1),
+                transaction.getPortionOwed(CARL.getName()));
+        assertEquals(BigFraction.ZERO,
+                transaction.getPortionOwed(Name.SELF));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,5 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIFTH_PERSON = Index.fromOneBased(5);
 }


### PR DESCRIPTION
Closes #54 
- Add `SettlePersonCommand`
- Add `getBalance` to `AddressBook`
- Add `getPortionOwed` to `Transaction` and the subsequent unit tests
- Add `assertTransactionCommandSuccess` to `CommandTestUtil` to account for Timestamp differences
- Add integration and unit tests for `SettleCommand`


Dependent: https://github.com/AY2324S1-CS2103T-W17-3/tp/pull/89
- Required for testing