### PR TITLE
Add sort by balance for persons

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -35,25 +35,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons = new UniquePersonList();
         transactions = new UniqueTransactionList();
     }
-
-    private final Comparator<Person> desc = (p1, p2) -> {
-        int balCompare = -transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
-        if (balCompare == 0) {
-            return p1.getName().compareTo(p2.getName());
-        }
-        return balCompare;
-    };
-    private final Comparator<Person> asc = (p1, p2) -> {
-        int balCompare = transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
-        if (balCompare == 0) {
-            return p1.getName().compareTo(p2.getName());
-        }
-        return balCompare;
-    };
     private Comparator<Person> currComparator;
 
     public AddressBook() {
-        this.currComparator = desc;
+        this.setDesc();
     }
 
     /**
@@ -183,7 +168,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Sets sort person to descending.
      */
     public void setDesc() {
-        currComparator = desc;
+        currComparator = (p1, p2) -> {
+            int balCompare = -transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
+            if (balCompare == 0) {
+                return p1.getName().compareTo(p2.getName());
+            }
+            return balCompare;
+        };
         sortPersons();
     }
 
@@ -191,7 +182,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Sets sort person to ascending.
      */
     public void setAsc() {
-        currComparator = asc;
+        currComparator = (p1, p2) -> {
+            int balCompare = transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
+            if (balCompare == 0) {
+                return p1.getName().compareTo(p2.getName());
+            }
+            return balCompare;
+        };
         sortPersons();
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.apache.commons.numbers.fraction.BigFraction;
@@ -35,7 +36,25 @@ public class AddressBook implements ReadOnlyAddressBook {
         transactions = new UniqueTransactionList();
     }
 
-    public AddressBook() {}
+    private final Comparator<Person> desc = (p1, p2) -> {
+        int balCompare = -transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
+        if (balCompare == 0) {
+            return p1.getName().compareTo(p2.getName());
+        }
+        return balCompare;
+    };
+    private final Comparator<Person> asc = (p1, p2) -> {
+        int balCompare = transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
+        if (balCompare == 0) {
+            return p1.getName().compareTo(p2.getName());
+        }
+        return balCompare;
+    };
+    private Comparator<Person> currComparator;
+
+    public AddressBook() {
+        this.currComparator = desc;
+    }
 
     /**
      * Creates an AddressBook using the Persons and Transactions in the {@code toBeCopied}
@@ -53,6 +72,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPersons(List<Person> persons) {
         this.persons.setPersons(persons);
+        sortPersons();
     }
 
 
@@ -62,6 +82,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setTransactions(List<Transaction> transactions) {
         this.transactions.setTransactions(transactions);
+        sortPersons();
     }
 
 
@@ -91,6 +112,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addPerson(Person p) {
         persons.add(p);
+        sortPersons();
     }
 
     /**
@@ -102,6 +124,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedPerson);
 
         persons.setPerson(target, editedPerson);
+        sortPersons();
     }
 
     /**
@@ -111,6 +134,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void removePerson(Person key) {
         persons.remove(key);
         transactions.deletePerson(key.getName(), persons.nameSet());
+        sortPersons();
     }
 
     //// transaction-level operations
@@ -130,6 +154,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void addTransaction(Transaction transaction) {
         requireNonNull(transaction);
         transactions.add(transaction);
+        sortPersons();
     }
 
     /**
@@ -142,6 +167,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedTransaction);
 
         transactions.setTransaction(target, editedTransaction);
+        sortPersons();
     }
 
     /**
@@ -150,6 +176,27 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeTransaction(Transaction key) {
         transactions.remove(key);
+        sortPersons();
+    }
+
+    /**
+     * Sets sort person to descending.
+     */
+    public void setDesc() {
+        currComparator = desc;
+        sortPersons();
+    }
+
+    /**
+     * Sets sort person to ascending.
+     */
+    public void setAsc() {
+        currComparator = asc;
+        sortPersons();
+    }
+
+    private void sortPersons() {
+        persons.sort(currComparator);
     }
 
     //// util methods
@@ -168,9 +215,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param name the name of the person
      */
     public BigFraction getBalance(Name name) {
-        return transactions.asUnmodifiableObservableList().stream()
-                .map(transaction -> transaction.getPortionOwed(name))
-                .reduce(BigFraction.ZERO, BigFraction::add);
+        return transactions.getBalance(name);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -35,10 +35,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons = new UniquePersonList();
         transactions = new UniqueTransactionList();
     }
-    private Comparator<Person> currComparator;
+    private Comparator<Person> personComparator;
 
     public AddressBook() {
-        this.setDesc();
+        this.setPersonDescendingBalance();
     }
 
     /**
@@ -167,8 +167,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Sets sort person to descending.
      */
-    public void setDesc() {
-        currComparator = (p1, p2) -> {
+    public void setPersonDescendingBalance() {
+        personComparator = (p1, p2) -> {
             int balCompare = -transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
             if (balCompare == 0) {
                 return p1.getName().compareTo(p2.getName());
@@ -181,8 +181,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Sets sort person to ascending.
      */
-    public void setAsc() {
-        currComparator = (p1, p2) -> {
+    public void setPersonAscendingBalance() {
+        personComparator = (p1, p2) -> {
             int balCompare = transactions.getBalance(p1.getName()).compareTo(transactions.getBalance(p2.getName()));
             if (balCompare == 0) {
                 return p1.getName().compareTo(p2.getName());
@@ -193,7 +193,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     private void sortPersons() {
-        persons.sort(currComparator);
+        persons.sort(personComparator);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -110,6 +111,10 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public ObservableList<Person> asUnmodifiableObservableList() {
         return internalUnmodifiableList;
+    }
+
+    public void sort(Comparator<Person> comp) {
+        internalList.sort(comp);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/transaction/UniqueTransactionList.java
+++ b/src/main/java/seedu/address/model/transaction/UniqueTransactionList.java
@@ -8,6 +8,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.numbers.fraction.BigFraction;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Name;
@@ -23,6 +25,20 @@ public class UniqueTransactionList implements Iterable<Transaction> {
     private final ObservableList<Transaction> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
 
+    /**
+     * Get balance for a person with a given name, within this list.
+     */
+    public BigFraction getBalance(Name name) {
+        return UniqueTransactionList.getBalance(name, internalList);
+    }
+
+    /**
+     * Get balance for a person with a given name, within a given list.
+     */
+    public static BigFraction getBalance(Name name, ObservableList<Transaction> lst) {
+        return lst.stream().map(transaction -> transaction.getPortionOwed(name))
+                .reduce(BigFraction.ZERO, BigFraction::add);
+    }
 
     /**
      * Returns true if the list contains an equivalent transaction as the given argument.

--- a/src/test/java/seedu/address/logic/commands/SettlePersonCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/SettlePersonCommandIntegrationTest.java
@@ -5,7 +5,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertTransactionComm
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIFTH_ELEMENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ELEMENT;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ELEMENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SEVENTH_ELEMENT;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.ELLE;
@@ -67,7 +67,7 @@ public class SettlePersonCommandIntegrationTest {
                 .withWeight("1").build())).build();
         expectedModel.addTransaction(transaction);
 
-        assertTransactionCommandSuccess(new SettlePersonCommand(INDEX_SECOND_ELEMENT), model,
+        assertTransactionCommandSuccess(new SettlePersonCommand(INDEX_SEVENTH_ELEMENT), model,
                 String.format(SettlePersonCommand.MESSAGE_SETTLE_PERSON_SUCCESS, personToSettle.getName()),
                 expectedModel);
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalTransactions.LUNCH;
 
 import java.util.Arrays;
@@ -23,6 +24,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.model.transaction.exceptions.DuplicateTransactionException;
+import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.TransactionBuilder;
 
@@ -120,6 +122,15 @@ public class AddressBookTest {
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getPersonList().remove(0));
+    }
+
+    @Test
+    public void sort() {
+        AddressBook ab = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).withTransaction(LUNCH).build();
+        ab.setAsc();
+        assertTrue(ALICE.equals(ab.getPersonList().get(0)));
+        ab.setDesc();
+        assertTrue(BENSON.equals(ab.getPersonList().get(0)));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -127,9 +127,9 @@ public class AddressBookTest {
     @Test
     public void sort() {
         AddressBook ab = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).withTransaction(LUNCH).build();
-        ab.setAsc();
+        ab.setPersonAscendingBalance();
         assertTrue(ALICE.equals(ab.getPersonList().get(0)));
-        ab.setDesc();
+        ab.setPersonDescendingBalance();
         assertTrue(BENSON.equals(ab.getPersonList().get(0)));
     }
 

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -2,6 +2,8 @@ package seedu.address.testutil;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.transaction.Transaction;
+
 
 /**
  * A utility class to help with building Addressbook objects.
@@ -25,6 +27,14 @@ public class AddressBookBuilder {
      */
     public AddressBookBuilder withPerson(Person person) {
         addressBook.addPerson(person);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Transaction} to the {@code AddressBook} that we are building.
+     */
+    public AddressBookBuilder withTransaction(Transaction transaction) {
+        addressBook.addTransaction(transaction);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -10,4 +10,5 @@ public class TypicalIndexes {
     public static final Index INDEX_SECOND_ELEMENT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_ELEMENT = Index.fromOneBased(3);
     public static final Index INDEX_FIFTH_ELEMENT = Index.fromOneBased(5);
+    public static final Index INDEX_SEVENTH_ELEMENT = Index.fromOneBased(7);
 }


### PR DESCRIPTION
Closes #57 

The sort is implemented in AddressBook instead of UniquePersonList.

Initially I tried passing in the comparators to be stored in UniquePersonList. Adding the final variable transactions to the comparator works.

However, it appears that the main function creates the AddressBook twice. The storage outputs a ReadOnlyAddressBook and a copy of this has to be made to get the AddressBook actually used by the model. The comparator references the inital UniquePersonList which is obselete.

So I implemented the sort in AddressBook instead.