### PR TITLE
Add ability to edit timestamp in EditTransactionCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTransactionCommand.java
@@ -160,7 +160,7 @@ public class EditTransactionCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(amount, description, payeeName, expenses);
+            return CollectionUtil.isAnyNonNull(amount, description, payeeName, timestamp, expenses);
         }
 
         public void setAmount(Amount amount) {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -16,4 +16,6 @@ public class CliSyntax {
 
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d=");
 
+    public static final Prefix PREFIX_TIMESTAMP = new Prefix("ts=");
+
 }

--- a/src/main/java/seedu/address/logic/parser/EditTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditTransactionCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COST;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditTransactionCommand;
@@ -24,7 +25,7 @@ public class EditTransactionCommandParser implements Parser<EditTransactionComma
         requireNonNull(args);
         // TODO: tokenize prefix for expense names and weights for v1.2b
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_COST, PREFIX_DESCRIPTION);
+                ArgumentTokenizer.tokenize(args, PREFIX_COST, PREFIX_DESCRIPTION, PREFIX_TIMESTAMP);
 
         Index index;
 
@@ -35,7 +36,7 @@ public class EditTransactionCommandParser implements Parser<EditTransactionComma
                     MESSAGE_INVALID_COMMAND_FORMAT, EditTransactionCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_COST, PREFIX_DESCRIPTION);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_COST, PREFIX_DESCRIPTION, PREFIX_TIMESTAMP);
 
         EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();
 
@@ -46,6 +47,10 @@ public class EditTransactionCommandParser implements Parser<EditTransactionComma
         if (argMultimap.getValue(PREFIX_COST).isPresent()) {
             editTransactionDescriptor.setAmount(
                     ParserUtil.parseAmount(argMultimap.getValue(PREFIX_COST).get()));
+        }
+        if (argMultimap.getValue(PREFIX_TIMESTAMP).isPresent()) {
+            editTransactionDescriptor.setTimestamp(
+                    ParserUtil.parseTimestamp(argMultimap.getValue(PREFIX_TIMESTAMP).get()));
         }
         // TODO: parseExpensesForEdit
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.Description;
+import seedu.address.model.transaction.Timestamp;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -140,6 +141,21 @@ public class ParserUtil {
             throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
         }
         return new Amount(trimmedAmount);
+    }
+
+    /**
+     * Parses a {@code String timestamp} into a {@code Timestamp}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @ throws ParseException if the given {@code timestamp} is invalid.
+     */
+    public static Timestamp parseTimestamp(String timestamp) throws ParseException {
+        requireNonNull(timestamp);
+        String trimmedTimestamp = timestamp.trim();
+        if (!Timestamp.isValidTimestamp(trimmedTimestamp)) {
+            throw new ParseException(Timestamp.MESSAGE_CONSTRAINTS);
+        }
+        return new Timestamp(trimmedTimestamp);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditTransactionCommandTest.java
@@ -51,17 +51,57 @@ class EditTransactionCommandTest {
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
-
+    public void execute_DescriptionFieldsSpecifiedUnfilteredList_success() {
         Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_ELEMENT.getZeroBased());
-        Timestamp firstTransactionTimestamp = firstTransaction.getTimestamp();
+        String descriptionString = "A New Dinner";
 
         TransactionBuilder transactionInList = new TransactionBuilder(firstTransaction);
-        Transaction editedTransaction = transactionInList.withDescription("A New Dinner").build();
-
+        Transaction editedTransaction = transactionInList.withDescription(descriptionString).build();
 
         EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
-                .withDescription("A New Dinner").build();
+                .withDescription(descriptionString).build();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_ELEMENT, descriptor);
+
+        String expectedMessage = String.format(
+                EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, Messages.format(editedTransaction));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        expectedModel.setTransaction(model.getFilteredTransactionList().get(0), editedTransaction);
+
+        assertTransactionCommandSuccess(editTransactionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_CostFieldSpecifiedUnfilteredList_success() {
+        Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_ELEMENT.getZeroBased());
+        String costString = "123.21";
+
+        TransactionBuilder transactionInList = new TransactionBuilder(firstTransaction);
+        Transaction editedTransaction = transactionInList.withAmount(costString).build();
+
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withAmount(costString).build();
+        EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_ELEMENT, descriptor);
+
+        String expectedMessage = String.format(
+                EditTransactionCommand.MESSAGE_EDIT_TRANSACTION_SUCCESS, Messages.format(editedTransaction));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        expectedModel.setTransaction(model.getFilteredTransactionList().get(0), editedTransaction);
+
+        assertTransactionCommandSuccess(editTransactionCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_TimestampFieldsSpecifiedUnfilteredList_success() {
+        Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_ELEMENT.getZeroBased());
+        String timestampString =  "2020-10-10T10:10:10.000";
+
+        TransactionBuilder transactionInList = new TransactionBuilder(firstTransaction);
+        Transaction editedTransaction = transactionInList.withTimestamp(timestampString).build();
+
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder()
+                .withTimestamp(timestampString).build();
         EditTransactionCommand editTransactionCommand = new EditTransactionCommand(INDEX_FIRST_ELEMENT, descriptor);
 
         String expectedMessage = String.format(

--- a/src/test/java/seedu/address/logic/commands/EditTransactionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditTransactionCommandTest.java
@@ -21,7 +21,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.transaction.Timestamp;
 import seedu.address.model.transaction.Transaction;
 import seedu.address.testutil.EditTransactionDescriptorBuilder;
 import seedu.address.testutil.TransactionBuilder;
@@ -51,7 +50,7 @@ class EditTransactionCommandTest {
     }
 
     @Test
-    public void execute_DescriptionFieldsSpecifiedUnfilteredList_success() {
+    public void execute_descriptionFieldSpecifiedUnfilteredList_success() {
         Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_ELEMENT.getZeroBased());
         String descriptionString = "A New Dinner";
 
@@ -72,7 +71,7 @@ class EditTransactionCommandTest {
     }
 
     @Test
-    public void execute_CostFieldSpecifiedUnfilteredList_success() {
+    public void execute_costFieldSpecifiedUnfilteredList_success() {
         Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_ELEMENT.getZeroBased());
         String costString = "123.21";
 
@@ -93,9 +92,9 @@ class EditTransactionCommandTest {
     }
 
     @Test
-    public void execute_TimestampFieldsSpecifiedUnfilteredList_success() {
+    public void execute_timestampFieldSpecifiedUnfilteredList_success() {
         Transaction firstTransaction = model.getFilteredTransactionList().get(INDEX_FIRST_ELEMENT.getZeroBased());
-        String timestampString =  "2020-10-10T10:10:10.000";
+        String timestampString = "2020-10-10T10:10:10.000";
 
         TransactionBuilder transactionInList = new TransactionBuilder(firstTransaction);
         Transaction editedTransaction = transactionInList.withTimestamp(timestampString).build();

--- a/src/test/java/seedu/address/logic/parser/EditTransactionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditTransactionCommandParserTest.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.EditTransactionCommand.MESSAGE_TRANSACTION_NOT_EDITED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COST;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ELEMENT;
@@ -16,6 +17,7 @@ import seedu.address.logic.commands.EditTransactionCommand;
 import seedu.address.logic.commands.EditTransactionCommand.EditTransactionDescriptor;
 import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.Description;
+import seedu.address.model.transaction.Timestamp;
 import seedu.address.testutil.EditTransactionDescriptorBuilder;
 
 class EditTransactionCommandParserTest {
@@ -23,9 +25,13 @@ class EditTransactionCommandParserTest {
     private static final String VALID_DESCRIPTION = "Dinner";
     private static final String VALID_COST = "10.00";
 
+    private static final String VALID_TIMESTAMP = "2020-10-10T10:10:10.100";
+
     private static final String INVALID_DESCRIPTION = " ";
 
     private static final String INVALID_COST = "1.3.0.1";
+
+    private static final String INVALID_TIMESTAMP = "20 October 2022";
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTransactionCommand.MESSAGE_USAGE);
@@ -70,7 +76,11 @@ class EditTransactionCommandParserTest {
                 "1" + " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION + " "
                         + PREFIX_COST + INVALID_COST, Amount.MESSAGE_CONSTRAINTS);
 
-        // two invalid values, only first invalid value reported (in order of description, cost)
+        // invalid timestamp
+        assertParseFailure(parser,
+                "1" + " " + PREFIX_TIMESTAMP + INVALID_TIMESTAMP, Timestamp.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported (in order of description, cost, timestamp)
         assertParseFailure(parser,
                 "1" + " " + PREFIX_COST + INVALID_COST + " "
                         + PREFIX_DESCRIPTION + INVALID_DESCRIPTION, Description.MESSAGE_CONSTRAINTS);
@@ -89,6 +99,12 @@ class EditTransactionCommandParserTest {
         // cost
         userInput = targetIndex.getOneBased() + " " + PREFIX_COST + VALID_COST;
         descriptor = new EditTransactionDescriptorBuilder().withAmount(VALID_COST).build();
+        expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // timestamp
+        userInput = targetIndex.getOneBased() + " " + PREFIX_TIMESTAMP + VALID_TIMESTAMP;
+        descriptor = new EditTransactionDescriptorBuilder().withTimestamp(VALID_TIMESTAMP).build();
         expectedCommand = new EditTransactionCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }


### PR DESCRIPTION
Closes #127

Uses new prefix `ts=`, followed by the time in ISO format.

e.g. `ts=2024-10-13T12:34:56.789`

Enhancement in the future: 
- [ ] change input time format to something more user friendly.

