### PR TITLE
Remove portion-related fields and methods

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTransactionCommand.java
@@ -87,6 +87,7 @@ public class EditTransactionCommand extends Command {
     /**
      * Creates and returns a {@code Transaction} with the details of {@code transactionToEdit}
      * edited with {@code editTransactionDescriptor}.
+     * Portions are not edited with this {@code EditTransactionCommand}
      */
     private static Transaction createEditedTransaction(Transaction transactionToEdit, EditTransactionDescriptor
             editTransactionDescriptor) {
@@ -96,14 +97,13 @@ public class EditTransactionCommand extends Command {
         Description updatedDescription = editTransactionDescriptor.getDescription().orElse(transactionToEdit
                 .getDescription());
         Name updatedPayeeName = editTransactionDescriptor.getPayeeName().orElse(transactionToEdit.getPayeeName());
-        Set<Portion> updatedPortions = editTransactionDescriptor.getPortions().orElse(transactionToEdit
-                .getPortions());
-
-        // Timestamp is edited here for testing purposes
         Timestamp updatedTimestamp = editTransactionDescriptor.getTimestamp().orElse(transactionToEdit
                 .getTimestamp());
 
-        return new Transaction(updatedAmount, updatedDescription, updatedPayeeName, updatedPortions, updatedTimestamp);
+
+        Set<Portion> existingPortions = transactionToEdit.getPortions();
+
+        return new Transaction(updatedAmount, updatedDescription, updatedPayeeName, existingPortions, updatedTimestamp);
     }
 
     @Override
@@ -134,12 +134,12 @@ public class EditTransactionCommand extends Command {
      * Stores the details to edit the transaction with. Each non-empty field value will replace the
      * corresponding field value of the transaction.
      * Note that "cost" is represented by {@code Amount} named {@code amount} in the model.
+     * EditTransactionDescriptor does not edit and store portions.
      */
     public static class EditTransactionDescriptor {
         private Amount amount;
         private Description description;
         private Name payeeName;
-        private Set<Portion> portions;
         private Timestamp timestamp;
 
         public EditTransactionDescriptor() {}
@@ -153,17 +153,13 @@ public class EditTransactionCommand extends Command {
             setDescription(toCopy.description);
             setPayeeName(toCopy.payeeName);
             setTimestamp(toCopy.timestamp);
-
-            if (toCopy.portions != null) {
-                setPortions(toCopy.portions);
-            }
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(amount, description, payeeName, timestamp, portions);
+            return CollectionUtil.isAnyNonNull(amount, description, payeeName, timestamp);
         }
 
         public void setAmount(Amount amount) {
@@ -190,26 +186,26 @@ public class EditTransactionCommand extends Command {
             return Optional.ofNullable(payeeName);
         }
 
-        /**
-         * Sets {@code portions} to this object's {@code portions}.
-         * A defensive copy of {@code portions} is used internally.
-         */
-        public void setPortions(Set<Portion> portions) {
-            if (!Objects.isNull(portions)) {
-                requireNonEmptyCollection(portions);
-                requireAllNonNull(portions);
-                this.portions = new HashSet<>(portions);
-            }
-            this.portions = null;
-        }
-
-        /**
-         * Returns an unmodifiable portion set, which throws {@code UnsupportedOperationException}
-         * if modification is attempted.
-         */
-        public Optional<Set<Portion>> getPortions() {
-            return (portions != null) ? Optional.of(Collections.unmodifiableSet(portions)) : Optional.empty();
-        }
+//        /**
+//         * Sets {@code portions} to this object's {@code portions}.
+//         * A defensive copy of {@code portions} is used internally.
+//         */
+//        public void setPortions(Set<Portion> portions) {
+//            if (!Objects.isNull(portions)) {
+//                requireNonEmptyCollection(portions);
+//                requireAllNonNull(portions);
+//                this.portions = new HashSet<>(portions);
+//            }
+//            this.portions = null;
+//        }
+//
+//        /**
+//         * Returns an unmodifiable portion set, which throws {@code UnsupportedOperationException}
+//         * if modification is attempted.
+//         */
+//        public Optional<Set<Portion>> getPortions() {
+//            return (portions != null) ? Optional.of(Collections.unmodifiableSet(portions)) : Optional.empty();
+//        }
 
         public void setTimestamp(Timestamp timestamp) {
             this.timestamp = timestamp;
@@ -234,7 +230,6 @@ public class EditTransactionCommand extends Command {
             return Objects.equals(amount, otherEditTransactionDescriptor.amount)
                     && Objects.equals(description, otherEditTransactionDescriptor.description)
                     && Objects.equals(payeeName, otherEditTransactionDescriptor.payeeName)
-                    && Objects.equals(portions, otherEditTransactionDescriptor.portions)
                     && Objects.equals(timestamp, otherEditTransactionDescriptor.timestamp);
         }
 
@@ -248,7 +243,6 @@ public class EditTransactionCommand extends Command {
                     .add("cost", amount)
                     .add("description", description)
                     .add("payeeName", payeeName)
-                    .add("portions", portions)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditTransactionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTransactionCommand.java
@@ -1,14 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireNonEmptyCollection;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COST;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -185,27 +181,6 @@ public class EditTransactionCommand extends Command {
         public Optional<Name> getPayeeName() {
             return Optional.ofNullable(payeeName);
         }
-
-//        /**
-//         * Sets {@code portions} to this object's {@code portions}.
-//         * A defensive copy of {@code portions} is used internally.
-//         */
-//        public void setPortions(Set<Portion> portions) {
-//            if (!Objects.isNull(portions)) {
-//                requireNonEmptyCollection(portions);
-//                requireAllNonNull(portions);
-//                this.portions = new HashSet<>(portions);
-//            }
-//            this.portions = null;
-//        }
-//
-//        /**
-//         * Returns an unmodifiable portion set, which throws {@code UnsupportedOperationException}
-//         * if modification is attempted.
-//         */
-//        public Optional<Set<Portion>> getPortions() {
-//            return (portions != null) ? Optional.of(Collections.unmodifiableSet(portions)) : Optional.empty();
-//        }
 
         public void setTimestamp(Timestamp timestamp) {
             this.timestamp = timestamp;

--- a/src/main/java/seedu/address/logic/parser/EditTransactionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditTransactionCommandParser.java
@@ -24,7 +24,6 @@ public class EditTransactionCommandParser implements Parser<EditTransactionComma
     */
     public EditTransactionCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        // TODO: tokenize prefix for portion names and weights for v1.2b
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COST, PREFIX_DESCRIPTION, PREFIX_NAME, PREFIX_TIMESTAMP);
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -121,7 +121,7 @@ public class AddressBookParserTest {
     public void parseCommand_editTransaction() throws Exception {
         Transaction transaction = new TransactionBuilder().build();
         EditTransactionDescriptor descriptor = new EditTransactionDescriptorBuilder(transaction)
-                .withoutPayeeNameAndPortions().withoutTimestamp().build();
+                .withoutTimestamp().build();
         EditTransactionCommand command = (EditTransactionCommand) parser.parseCommand(
                 EditTransactionCommand.COMMAND_WORD + " " + INDEX_FIRST_ELEMENT.getOneBased() + " "
                         + getEditTransactionDescriptorDetails(descriptor));

--- a/src/test/java/seedu/address/testutil/EditTransactionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditTransactionDescriptorBuilder.java
@@ -34,18 +34,8 @@ public class EditTransactionDescriptorBuilder {
         descriptor.setAmount(transaction.getAmount());
         descriptor.setDescription(transaction.getDescription());
         descriptor.setPayeeName(transaction.getPayeeName());
-        descriptor.setPortions(transaction.getPortions());
+//        descriptor.setPortions(transaction.getPortions());
         descriptor.setTimestamp(transaction.getTimestamp());
-    }
-
-    /**
-     * Returns an {@code EditTransactionDescriptor} with fields {@code payeeName} and {@code portions} set to null.
-     * This is used for v1.2 testing {@code EditTransactionCommand} without {@code payeeName} and {@code portions}.
-     */
-    public EditTransactionDescriptorBuilder withoutPayeeNameAndPortions() {
-        descriptor.setPayeeName(null);
-        descriptor.setPortions(null);
-        return this;
     }
 
     /**
@@ -81,22 +71,6 @@ public class EditTransactionDescriptorBuilder {
         return this;
     }
 
-    /**
-     * Parses the {@code portions} into a {@code Set<Portion>}
-     * and set it to the {@code EditTransactionDescriptor}.
-     * Arguments should be in pairs of {@code name} and {@code weight}.
-     */
-    public EditTransactionDescriptorBuilder withPortions(String... portions) {
-        if (portions.length % 2 != 0) {
-            throw new IllegalArgumentException("Arguments should be in pairs of name and weight");
-        }
-        Set<Portion> portionSet = new HashSet<>();
-        for (int i = 0; i < portions.length; i += 2) {
-            portionSet.add(new PortionBuilder().withName(portions[i]).withWeight(portions[i + 1]).build());
-        }
-        descriptor.setPortions(portionSet);
-        return this;
-    }
 
     /**
      * Sets the {@code Timestamp} of the {@code EditTransactionDescriptor} that we are building.

--- a/src/test/java/seedu/address/testutil/EditTransactionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditTransactionDescriptorBuilder.java
@@ -1,15 +1,11 @@
 package seedu.address.testutil;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import seedu.address.logic.commands.EditTransactionCommand.EditTransactionDescriptor;
 import seedu.address.model.person.Name;
 import seedu.address.model.transaction.Amount;
 import seedu.address.model.transaction.Description;
 import seedu.address.model.transaction.Timestamp;
 import seedu.address.model.transaction.Transaction;
-import seedu.address.model.transaction.portion.Portion;
 
 /**
  * A utility class to help with building EditTransactionDescriptor objects.
@@ -34,7 +30,6 @@ public class EditTransactionDescriptorBuilder {
         descriptor.setAmount(transaction.getAmount());
         descriptor.setDescription(transaction.getDescription());
         descriptor.setPayeeName(transaction.getPayeeName());
-//        descriptor.setPortions(transaction.getPortions());
         descriptor.setTimestamp(transaction.getTimestamp());
     }
 

--- a/src/test/java/seedu/address/testutil/TransactionUtil.java
+++ b/src/test/java/seedu/address/testutil/TransactionUtil.java
@@ -2,6 +2,8 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COST;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
 
 import seedu.address.logic.commands.EditTransactionCommand.EditTransactionDescriptor;
 
@@ -14,12 +16,15 @@ public class TransactionUtil {
      * Returns the part of command string for the given {@code EditTransactionDescriptor}'s details.
      */
     public static String getEditTransactionDescriptorDetails(EditTransactionDescriptor descriptor) {
-        //TODO: add payeeName and expenses in v1.3
         StringBuilder sb = new StringBuilder();
         descriptor.getAmount().ifPresent(amount ->
                 sb.append(PREFIX_COST).append(amount).append(" "));
         descriptor.getDescription().ifPresent(description ->
                 sb.append(PREFIX_DESCRIPTION).append(description.value).append(" "));
+        descriptor.getPayeeName().ifPresent(payeeName ->
+                sb.append(PREFIX_NAME).append(payeeName).append(" "));
+        descriptor.getTimestamp().ifPresent(timestamp ->
+                sb.append(PREFIX_TIMESTAMP).append(timestamp).append(" "));
         return sb.toString();
     }
 }


### PR DESCRIPTION
EditTransaction command and related classes and methods should not interact with Transaction portions.

Portion-related commands and methods are handled by UpdatePortionCommand.