### PR TITLE
Fix outdated use of `Message.format(Transaction)`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UpdatePortionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdatePortionCommand.java
@@ -88,7 +88,7 @@ public class UpdatePortionCommand extends Command {
         model.setTransaction(transactionToEdit, transactionWithUpdatedPortions);
         model.updateFilteredTransactionList(Model.PREDICATE_SHOW_ALL_TRANSACTIONS);
         return new CommandResult(
-                String.format(MESSAGE_UPDATE_PORTION_SUCCESS, Messages.format(transactionWithUpdatedPortions)));
+                String.format(MESSAGE_UPDATE_PORTION_SUCCESS, Messages.format(transactionWithUpdatedPortions, true)));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/UpdatePortionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdatePortionCommandTest.java
@@ -56,7 +56,7 @@ class UpdatePortionCommandTest {
         UpdatePortionCommand updatePortionCommand = new UpdatePortionCommand(INDEX_FIRST_ELEMENT, descriptor);
 
         String expectedMessage = String.format(UpdatePortionCommand.MESSAGE_UPDATE_PORTION_SUCCESS,
-                Messages.format(editedTransaction));
+                Messages.format(editedTransaction, true));
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setTransaction(model.getFilteredTransactionList().get(0), editedTransaction);
 
@@ -79,7 +79,7 @@ class UpdatePortionCommandTest {
         UpdatePortionCommand updatePortionCommand = new UpdatePortionCommand(INDEX_THIRD_ELEMENT, descriptor);
 
         String expectedMessage = String.format(UpdatePortionCommand.MESSAGE_UPDATE_PORTION_SUCCESS,
-                Messages.format(editedTransaction));
+                Messages.format(editedTransaction, true));
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setTransaction(model.getFilteredTransactionList().get(2), editedTransaction);
 
@@ -131,7 +131,7 @@ class UpdatePortionCommandTest {
         UpdatePortionCommand updatePortionCommand = new UpdatePortionCommand(INDEX_FIRST_ELEMENT, descriptor);
 
         String expectedMessage = String.format(UpdatePortionCommand.MESSAGE_UPDATE_PORTION_SUCCESS,
-                Messages.format(editedTransaction));
+                Messages.format(editedTransaction, true));
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setTransaction(model.getFilteredTransactionList().get(0), editedTransaction);
 
@@ -155,7 +155,7 @@ class UpdatePortionCommandTest {
                 new UpdatePortionDescriptorBuilder(newPortion).build());
 
         String expectedMessage = String.format(UpdatePortionCommand.MESSAGE_UPDATE_PORTION_SUCCESS,
-                Messages.format(editedTransaction));
+                Messages.format(editedTransaction, true));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setTransaction(model.getFilteredTransactionList().get(0), editedTransaction);


### PR DESCRIPTION
Resolve some conflicts between #167 and #168. Will force-merge to fix the master immediately.