### PR TITLE
Add overloaded method for formatting Transaction

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -55,7 +55,25 @@ public class Messages {
     }
 
     /**
+     * Formats the {@code transaction} for display to the user, including the timestamp.
+     */
+    public static String format(Transaction transaction) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(transaction.getDescription());
+        builder.append("; Timestamp: ")
+                .append(transaction.getTimestamp());
+        builder.append("; Amount: ")
+                .append(transaction.getAmount())
+                .append("; Paid by: ")
+                .append(transaction.getPayeeName())
+                .append("; Portions: ");
+        transaction.getPortions().forEach(builder::append);
+        return builder.toString();
+    }
+
+    /**
      * Formats the {@code transaction} for display to the user.
+     * @param includeTimestamp whether to include the timestamp in the message.
      */
     public static String format(Transaction transaction, boolean includeTimestamp) {
         final StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
Default method includes timestamp in the output message.

Overloaded method takes in another boolean argument `includeTimestamp`.

Open to suggestions, should we rename the overloaded method to `formatWithoutTimestamp` instead, and remove the extra parameter?