### PR TITLE
Add navigable Ui with hotkeys

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -40,6 +40,14 @@ public class CommandBox extends UiPartFocusable<Region> {
     }
 
     /**
+     * Un-focuses on the command box.
+     * Command box automatically un-focuses when another UI element is focused.
+     */
+    public void unFocus() {
+        // command box automatically un-focuses when another UI element is focused
+    }
+
+    /**
      * Handles the Enter button pressed event.
      */
     @FXML

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -11,7 +11,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * The UI component that is responsible for receiving user command inputs.
  */
-public class CommandBox extends UiPart<Region> {
+public class CommandBox extends UiPartFocusable<Region> {
 
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
@@ -29,6 +29,14 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+    }
+
+
+    /**
+     * Focuses on the command box.
+     */
+    public void focus() {
+        commandTextField.requestFocus();
     }
 
     /**

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpWindow extends UiPartFocusable<Stage> {
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -90,6 +90,14 @@ public class HelpWindow extends UiPartFocusable<Stage> {
     }
 
     /**
+     * Un-focuses on the help window.
+     * Help window automatically un-focuses when another UI element is focused.
+     */
+    public void unFocus() {
+        // help window automatically un-focuses when another UI element is focused
+    }
+
+    /**
      * Copies the URL to the user guide to the clipboard.
      */
     @FXML

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -13,7 +13,7 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpWindow extends UiPart<Stage> {
+public class HelpWindow extends UiPartFocusable<Stage> {
 
     public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -110,7 +110,7 @@ public class MainWindow extends UiPart<Stage> {
         });
     }
 
-    private void setKeyNavigations(UiPartFocusable<?> uiPartFocusable, KeyCode keyCode) {
+    private void setKeyNavigation(UiPartFocusable<?> uiPartFocusable, KeyCode keyCode) {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             logger.info("keyPressed" + event.getCode().toString());
             if (event.getCode() == keyCode) {
@@ -141,9 +141,9 @@ public class MainWindow extends UiPart<Stage> {
      * Sets up the key navigation for the UI.
      */
     void setKeyNavigations() {
-        setKeyNavigations(personListPanel, KeyCode.LEFT);
-        setKeyNavigations(transactionListPanel, KeyCode.RIGHT);
-        setKeyNavigations(commandBox, KeyCode.TAB);
+        setKeyNavigation(personListPanel, KeyCode.LEFT);
+        setKeyNavigation(transactionListPanel, KeyCode.RIGHT);
+        setKeyNavigation(commandBox, KeyCode.TAB);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -31,6 +31,8 @@ public class MainWindow extends UiPart<Stage> {
     private Stage primaryStage;
     private Logic logic;
 
+    private UiPartFocusable<?> focusedUiPart;
+
     // Independent Ui parts residing in this Ui container
     private TransactionListPanel transactionListPanel;
     private PersonListPanel personListPanel;
@@ -113,7 +115,12 @@ public class MainWindow extends UiPart<Stage> {
     private void setKeyNavigation(UiPartFocusable<?> uiPartFocusable, KeyCode keyCode) {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == keyCode) {
+                // un-focus everything first
+                if (focusedUiPart != null) {
+                    focusedUiPart.unFocus();
+                }
                 uiPartFocusable.focus();
+                focusedUiPart = uiPartFocusable;
                 event.consume();
             }
         });

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -6,6 +6,7 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
@@ -75,6 +76,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private void setAccelerators() {
         setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
+        setArrowKeyNavigation();
     }
 
     /**
@@ -102,6 +104,18 @@ public class MainWindow extends UiPart<Stage> {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getTarget() instanceof TextInputControl && keyCombination.match(event)) {
                 menuItem.getOnAction().handle(new ActionEvent());
+                event.consume();
+            }
+        });
+    }
+
+    private void setArrowKeyNavigation() {
+        getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.RIGHT) {
+                transactionListPanel.focusOnFirstTransaction();
+                event.consume();
+            } else if (event.getCode() == KeyCode.LEFT) {
+                personListPanel.focusOnFirstPerson();
                 event.consume();
             }
         });

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -37,6 +37,8 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
+    private CommandBox commandBox;
+
     @FXML
     private StackPane commandBoxPlaceholder;
 
@@ -134,7 +136,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -112,7 +112,6 @@ public class MainWindow extends UiPart<Stage> {
 
     private void setKeyNavigation(UiPartFocusable<?> uiPartFocusable, KeyCode keyCode) {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            logger.info("keyPressed" + event.getCode().toString());
             if (event.getCode() == keyCode) {
                 uiPartFocusable.focus();
                 event.consume();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -78,7 +78,6 @@ public class MainWindow extends UiPart<Stage> {
 
     private void setAccelerators() {
         setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
-        setArrowKeyNavigation();
     }
 
     /**
@@ -111,13 +110,11 @@ public class MainWindow extends UiPart<Stage> {
         });
     }
 
-    private void setArrowKeyNavigation() {
+    private void setKeyNavigations(UiPartFocusable<?> uiPartFocusable, KeyCode keyCode) {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (event.getCode() == KeyCode.RIGHT) {
-                transactionListPanel.focusOnFirstTransaction();
-                event.consume();
-            } else if (event.getCode() == KeyCode.LEFT) {
-                personListPanel.focusOnFirstPerson();
+            logger.info("keyPressed" + event.getCode().toString());
+            if (event.getCode() == keyCode) {
+                uiPartFocusable.focus();
                 event.consume();
             }
         });
@@ -138,6 +135,15 @@ public class MainWindow extends UiPart<Stage> {
 
         commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+    }
+
+    /**
+     * Sets up the key navigation for the UI.
+     */
+    void setKeyNavigations() {
+        setKeyNavigations(personListPanel, KeyCode.LEFT);
+        setKeyNavigations(transactionListPanel, KeyCode.RIGHT);
+        setKeyNavigations(commandBox, KeyCode.TAB);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -6,7 +6,6 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
-import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -112,10 +112,9 @@ public class MainWindow extends UiPart<Stage> {
         });
     }
 
-    private void setKeyNavigation(UiPartFocusable<?> uiPartFocusable, KeyCode keyCode) {
+    private void setKeyNavigation(UiPartFocusable<?> uiPartFocusable, KeyCombination keyCombination) {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (event.getCode() == keyCode) {
-                // un-focus everything first
+            if (keyCombination.match(event)) {
                 if (focusedUiPart != null) {
                     focusedUiPart.unFocus();
                 }
@@ -147,9 +146,9 @@ public class MainWindow extends UiPart<Stage> {
      * Sets up the key navigation for the UI.
      */
     void setKeyNavigations() {
-        setKeyNavigation(personListPanel, KeyCode.LEFT);
-        setKeyNavigation(transactionListPanel, KeyCode.RIGHT);
-        setKeyNavigation(commandBox, KeyCode.TAB);
+        setKeyNavigation(personListPanel, KeyCombination.keyCombination("Shift+LEFT"));
+        setKeyNavigation(transactionListPanel, KeyCombination.keyCombination("Shift+RIGHT"));
+        setKeyNavigation(commandBox, KeyCombination.keyCombination("Tab"));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -31,6 +31,13 @@ public class PersonListPanel extends UiPart<Region> {
         personListView.setCellFactory(listView -> new PersonListViewCell(transactionList));
     }
 
+    public void focusOnFirstPerson() {
+        if (!personListView.getItems().isEmpty()) {
+            personListView.requestFocus();
+            personListView.getSelectionModel().select(0);
+        }
+    }
+
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -15,7 +15,7 @@ import seedu.address.model.transaction.UniqueTransactionList;
 /**
  * Panel containing the list of persons.
  */
-public class PersonListPanel extends UiPart<Region> {
+public class PersonListPanel extends UiPartFocusable<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
@@ -31,7 +31,7 @@ public class PersonListPanel extends UiPart<Region> {
         personListView.setCellFactory(listView -> new PersonListViewCell(transactionList));
     }
 
-    public void focusOnFirstPerson() {
+    public void focus() {
         if (!personListView.getItems().isEmpty()) {
             personListView.requestFocus();
             personListView.getSelectionModel().select(0);

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -31,6 +31,9 @@ public class PersonListPanel extends UiPartFocusable<Region> {
         personListView.setCellFactory(listView -> new PersonListViewCell(transactionList));
     }
 
+    /**
+     * Focuses on the person list.
+     */
     public void focus() {
         if (!personListView.getItems().isEmpty()) {
             personListView.requestFocus();

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -42,6 +42,14 @@ public class PersonListPanel extends UiPartFocusable<Region> {
     }
 
     /**
+     * Un-focuses on the person list.
+     * This is done by clearing the selection in the list view.
+     */
+    public void unFocus() {
+        personListView.getSelectionModel().clearSelection();
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -25,4 +25,6 @@ public class ResultDisplay extends UiPart<Region> {
         resultDisplay.setText(feedbackToUser);
     }
 
+
+
 }

--- a/src/main/java/seedu/address/ui/TransactionListPanel.java
+++ b/src/main/java/seedu/address/ui/TransactionListPanel.java
@@ -6,6 +6,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
+import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.transaction.Transaction;
@@ -27,6 +28,13 @@ public class TransactionListPanel extends UiPart<Region> {
         super(FXML);
         transactionListView.setItems(transactionList);
         transactionListView.setCellFactory(listView -> new TransactionListViewCell());
+    }
+
+    public void focusOnFirstTransaction() {
+        if (!transactionListView.getItems().isEmpty()) {
+            transactionListView.requestFocus();
+            transactionListView.getSelectionModel().select(0);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/TransactionListPanel.java
+++ b/src/main/java/seedu/address/ui/TransactionListPanel.java
@@ -40,6 +40,14 @@ public class TransactionListPanel extends UiPartFocusable<Region> {
     }
 
     /**
+     * Un-focuses on the transaction list.
+     * This is done by clearing the selection in the list view.
+     */
+    public void unFocus() {
+        transactionListView.getSelectionModel().clearSelection();
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code Transaction} using a {@code TransactionCard}.
      */
     class TransactionListViewCell extends ListCell<Transaction> {

--- a/src/main/java/seedu/address/ui/TransactionListPanel.java
+++ b/src/main/java/seedu/address/ui/TransactionListPanel.java
@@ -6,7 +6,6 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
-import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.transaction.Transaction;
@@ -30,6 +29,9 @@ public class TransactionListPanel extends UiPartFocusable<Region> {
         transactionListView.setCellFactory(listView -> new TransactionListViewCell());
     }
 
+    /**
+     * Focuses on the transaction list.
+     */
     public void focus() {
         if (!transactionListView.getItems().isEmpty()) {
             transactionListView.requestFocus();

--- a/src/main/java/seedu/address/ui/TransactionListPanel.java
+++ b/src/main/java/seedu/address/ui/TransactionListPanel.java
@@ -14,7 +14,7 @@ import seedu.address.model.transaction.Transaction;
 /**
  * Panel containing the list of transactions.
  */
-public class TransactionListPanel extends UiPart<Region> {
+public class TransactionListPanel extends UiPartFocusable<Region> {
     private static final String FXML = "TransactionListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(TransactionListPanel.class);
 
@@ -30,7 +30,7 @@ public class TransactionListPanel extends UiPart<Region> {
         transactionListView.setCellFactory(listView -> new TransactionListViewCell());
     }
 
-    public void focusOnFirstTransaction() {
+    public void focus() {
         if (!transactionListView.getItems().isEmpty()) {
             transactionListView.requestFocus();
             transactionListView.getSelectionModel().select(0);

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -43,6 +43,7 @@ public class UiManager implements Ui {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
+            mainWindow.setKeyNavigations();
 
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));

--- a/src/main/java/seedu/address/ui/UiPartFocusable.java
+++ b/src/main/java/seedu/address/ui/UiPartFocusable.java
@@ -53,4 +53,9 @@ public abstract class UiPartFocusable<T> extends UiPart<T> {
      * Focuses on the root node of UiPartFocusable.
      */
     public abstract void focus();
+
+    /**
+     * Un-focuses on the root node of UiPartFocusable.
+     */
+    public abstract void unFocus();
 }

--- a/src/main/java/seedu/address/ui/UiPartFocusable.java
+++ b/src/main/java/seedu/address/ui/UiPartFocusable.java
@@ -2,7 +2,10 @@ package seedu.address.ui;
 
 import java.net.URL;
 
-public abstract class UiPartFocusable<T> extends UiPart<T>{
+/**
+ * Represents a UiPart that can be focused on.
+ */
+public abstract class UiPartFocusable<T> extends UiPart<T> {
 
     /**
      * Constructs a UiPart with the specified FXML file URL.

--- a/src/main/java/seedu/address/ui/UiPartFocusable.java
+++ b/src/main/java/seedu/address/ui/UiPartFocusable.java
@@ -1,0 +1,53 @@
+package seedu.address.ui;
+
+import java.net.URL;
+
+public abstract class UiPartFocusable<T> extends UiPart<T>{
+
+    /**
+     * Constructs a UiPart with the specified FXML file URL.
+     * The FXML file must not specify the {@code fx:controller} attribute.
+     *
+     * @param fxmlFileUrl
+     */
+    public UiPartFocusable(URL fxmlFileUrl) {
+        super(fxmlFileUrl);
+    }
+
+    /**
+     * Constructs a UiPart using the specified FXML file within {@link #FXML_FILE_FOLDER}.
+     *
+     * @param fxmlFileName
+     * @see #UiPartFocusable(URL)
+     */
+    public UiPartFocusable(String fxmlFileName) {
+        super(fxmlFileName);
+    }
+
+    /**
+     * Constructs a UiPart with the specified FXML file URL and root object.
+     * The FXML file must not specify the {@code fx:controller} attribute.
+     *
+     * @param fxmlFileUrl
+     * @param root
+     */
+    public UiPartFocusable(URL fxmlFileUrl, T root) {
+        super(fxmlFileUrl, root);
+    }
+
+    /**
+     * Constructs a UiPart with the specified FXML file within {@link #FXML_FILE_FOLDER} and root object.
+     *
+     * @param fxmlFileName
+     * @param root
+     * @see #UiPartFocusable(URL, T)
+     */
+    public UiPartFocusable(String fxmlFileName, T root) {
+        super(fxmlFileName, root);
+    }
+
+    /**
+     * Focuses on the root node of UiPartFocusable.
+     */
+    public abstract void focus();
+}


### PR DESCRIPTION
Closes #163

Add key navigations to the Ui
    
 Hotkeys:
    `Shift` + `<-`  (Shift + Left Arrow Key): focus on personList
   `Shift` + `->` (Shift + Right Arrow Key): focus on transactionList
    `TAB` (Tab Key): focus on the commandBox

Users can still use up and down arrow keys to scroll within each list.
    

  Changes made:
  Added new UiPartFocusable abstract class that extends UiPart.
  Only difference is that it has an additional method focus().

  CommandBox, HelpWindow, PersonListPanel and TransactionListPanel
  now extends from the new UiPartFocusable class.