### PR TITLE
[Enhacement] Add result display focus state

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -148,7 +148,8 @@ public class MainWindow extends UiPart<Stage> {
     void setKeyNavigations() {
         setKeyNavigation(personListPanel, KeyCombination.keyCombination("Shift+LEFT"));
         setKeyNavigation(transactionListPanel, KeyCombination.keyCombination("Shift+RIGHT"));
-        setKeyNavigation(commandBox, KeyCombination.keyCombination("Tab"));
+        setKeyNavigation(resultDisplay, KeyCombination.keyCombination("Shift+UP"));
+        setKeyNavigation(commandBox, KeyCombination.keyCombination("Shift+DOWN"));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -146,10 +146,10 @@ public class MainWindow extends UiPart<Stage> {
      * Sets up the key navigation for the UI.
      */
     void setKeyNavigations() {
-        setKeyNavigation(personListPanel, KeyCombination.keyCombination("Shift+LEFT"));
-        setKeyNavigation(transactionListPanel, KeyCombination.keyCombination("Shift+RIGHT"));
-        setKeyNavigation(resultDisplay, KeyCombination.keyCombination("Shift+UP"));
-        setKeyNavigation(commandBox, KeyCombination.keyCombination("Shift+DOWN"));
+        setKeyNavigation(personListPanel, KeyCombination.keyCombination("Alt+LEFT"));
+        setKeyNavigation(transactionListPanel, KeyCombination.keyCombination("Alt+RIGHT"));
+        setKeyNavigation(resultDisplay, KeyCombination.keyCombination("Alt+UP"));
+        setKeyNavigation(commandBox, KeyCombination.keyCombination("Alt+DOWN"));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -9,7 +9,7 @@ import javafx.scene.layout.Region;
 /**
  * A ui for the status bar that is displayed at the header of the application.
  */
-public class ResultDisplay extends UiPart<Region> {
+public class ResultDisplay extends UiPartFocusable<Region> {
 
     private static final String FXML = "ResultDisplay.fxml";
 
@@ -25,6 +25,18 @@ public class ResultDisplay extends UiPart<Region> {
         resultDisplay.setText(feedbackToUser);
     }
 
+    /**
+     * Focuses on the result display.
+     */
+    public void focus() {
+        resultDisplay.requestFocus();
+    }
 
-
+    /**
+     * Un-focuses on the result display.
+     * Command box automatically un-focuses when another UI element is focused.
+     */
+    public void unFocus() {
+        // result display automatically un-focuses when another UI element is focused
+    }
 }

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -185,7 +185,7 @@
 }
 
 #portionListView .list-cell:filled:odd {
-    -fx-background-color: #dbeafe;
+    -fx-background-color: #e0f2fe;
 }
 
 #portionListView .list-cell:filled:selected {

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -420,6 +420,10 @@
     -fx-background-radius: 0;
 }
 
+#resultDisplay:focused {
+    -fx-background-color: #3b82f6, #3b82f6, #3b82f6, #3b82f6;
+}
+
 #tags {
     -fx-hgap: 7;
     -fx-vgap: 3;


### PR DESCRIPTION
- Added shift+up shortcut to focus on the result display.
- Changed from tab to shift+down to focus on the command box.
- Changed shade of odd-indexed portion list to avoid background clash between list-view focus state and portion-list.

![image](https://github.com/AY2324S1-CS2103T-W17-3/tp/assets/89729098/cc2231e4-9904-4286-80f3-033995571fe1)
