### PR TITLE
Add check for '=' in address validation

### DIFF
--- a/src/main/java/seedu/spendnsplit/model/person/Address.java
+++ b/src/main/java/seedu/spendnsplit/model/person/Address.java
@@ -15,13 +15,9 @@ public class Address {
     /**
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
+     * There must not be any equal sign "=" in the address.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
-
-    /**
-     * Must not contain the equal sign anywhere in the address.
-     */
-    public static final String VALIDATION_REGEX_NO_EQUAL_SIGN = "^[^=]*$";
+    public static final String VALIDATION_REGEX = "^[^ =][^=]*$";
 
     public final String value;
 
@@ -40,7 +36,7 @@ public class Address {
      * Returns true if a given string is a valid address.
      */
     public static boolean isValidAddress(String test) {
-        return test.matches(VALIDATION_REGEX) && test.matches(VALIDATION_REGEX_NO_EQUAL_SIGN);
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/spendnsplit/model/person/Address.java
+++ b/src/main/java/seedu/spendnsplit/model/person/Address.java
@@ -16,7 +16,7 @@ public class Address {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "[^=]*$";
 
     public final String value;
 

--- a/src/main/java/seedu/spendnsplit/model/person/Address.java
+++ b/src/main/java/seedu/spendnsplit/model/person/Address.java
@@ -12,11 +12,16 @@ public class Address {
     public static final String MESSAGE_CONSTRAINTS =
             "Addresses should not be blank and should not contain the equal sign";
 
-    /*
+    /**
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^=]*$";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    /**
+     * Must not contain the equal sign anywhere in the address.
+     */
+    public static final String VALIDATION_REGEX_NO_EQUAL_SIGN = "^[^=]*$";
 
     public final String value;
 
@@ -35,7 +40,7 @@ public class Address {
      * Returns true if a given string is a valid address.
      */
     public static boolean isValidAddress(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.matches(VALIDATION_REGEX_NO_EQUAL_SIGN);
     }
 
     @Override

--- a/src/main/java/seedu/spendnsplit/model/person/TelegramHandle.java
+++ b/src/main/java/seedu/spendnsplit/model/person/TelegramHandle.java
@@ -20,9 +20,9 @@ public class TelegramHandle {
     public final String value;
 
     /**
-     * Constructs an {@code Address}.
+     * Constructs a {@code TelegramHandle}.
      *
-     * @param address A valid address.
+     * @param telegramHandle A valid telegramHandle.
      */
     public TelegramHandle(String telegramHandle) {
         requireNonNull(telegramHandle);

--- a/src/test/java/seedu/spendnsplit/model/person/AddressTest.java
+++ b/src/test/java/seedu/spendnsplit/model/person/AddressTest.java
@@ -27,6 +27,9 @@ public class AddressTest {
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
         assertFalse(Address.isValidAddress(" ")); // spaces only
+        assertFalse(Address.isValidAddress("Blk=456, Den Road, #01-355")); // with equal sign
+        assertFalse(Address.isValidAddress("dd=")); // with trailing equal sign
+        assertFalse(Address.isValidAddress("Leng Inc adr2=dd=")); // with many equal signs
 
         // valid addresses
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));


### PR DESCRIPTION
Closes #270 


Should we also add this check for `=` for other fields like tags and telegramHandles as well?